### PR TITLE
ci: add GitHub Actions workflow and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: clippy, rustfmt
+        override: true
+    - name: Run checks
+      run: make ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Makefile with common development tasks
 - GitHub Actions workflow running `make ci` for formatting, linting, and tests
-- Initial changelog and README updates
+- Add initial changelog
+- Add README.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: fmt fmt-check lint test build doc clean ci
+
+fmt:
+	cargo fmt --all
+
+fmt-check:
+	cargo fmt --all -- --check
+
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+test:
+	cargo test --workspace --all-features
+
+build:
+	cargo build --workspace --all-features
+
+doc:
+	cargo doc --workspace --all-features --no-deps
+
+clean:
+	cargo clean
+
+ci: fmt-check lint test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test the workspace
- add Makefile with common development tasks and use it in CI

## Testing
- `cargo fmt --all -- --check`
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_6891df1943f083219620fe4158ccae3e