### PR TITLE
ci: add GitHub Actions workflow and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: clippy, rustfmt
+        override: true
+    - name: Run checks
+      run: make ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Makefile with common development tasks
+- GitHub Actions workflow running `make ci` for formatting, linting, and tests
+- Initial changelog and README updates

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: fmt fmt-check lint test build doc clean ci
+
+fmt:
+	cargo fmt --all
+
+fmt-check:
+	cargo fmt --all -- --check
+
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+test:
+	cargo test --workspace --all-features
+
+build:
+	cargo build --workspace --all-features
+
+doc:
+	cargo doc --workspace --all-features --no-deps
+
+clean:
+	cargo clean
+
+ci: fmt-check lint test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ aei-framework/
 
 ## Getting started
 
+You can use Cargo directly or the provided Makefile for common development tasks.
+
 ```bash
 # Build the entire workspace
 cargo build
@@ -31,6 +33,9 @@ cargo test
 
 # Run an example
 cargo run --example basic
+
+# Format, lint and test using the Makefile
+make ci
 ```
 
 ## Crates
@@ -44,6 +49,10 @@ cargo run --example basic
 ## Contributing
 
 AEIF welcomes contributions from researchers and developers. Feel free to open issues and pull requests.
+
+GitHub Actions runs `make ci` on pushes and pull requests targeting `main` to ensure the workspace builds and tests successfully.
+
+See [CHANGELOG.md](CHANGELOG.md) for a list of notable changes.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test the workspace
- add Makefile with common development tasks and use it in CI
- document Makefile usage and CI in the README
- start a changelog to track project changes

## Testing
- `cargo fmt --all -- --check`
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_6891df1943f083219620fe4158ccae3e