### PR TITLE
feat: add configurable activations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,37 @@ AEI Framework is an open source Rust framework for building dynamic, modular, sc
 ## Quick Example
 
 ```rust
-use aei_framework::Network;
+use aei_framework::{Activation, Network};
 
 fn main() {
     let mut net = Network::new();
-    let a = net.add_neuron();
-    let b = net.add_neuron();
-    net.add_synapse(a, b, 0.5);
-    net.propagate(a, 2.0);
-    println!("Value of neuron b: {:?}", net.value(b));
+    let input = net.add_neuron(); // Uses the default identity activation
+    let hidden = net.add_neuron_with_activation(Activation::ReLU);
+    let output = net.add_neuron_with_activation(Activation::Sigmoid);
+    net.add_synapse(input, hidden, 1.0);
+    net.add_synapse(hidden, output, 1.0);
+    net.propagate(input, -0.5);
+    println!("Value of output neuron: {:?}", net.value(output));
 }
+```
+
+## Activation Functions
+
+Neurons support several activation functions:
+
+- `Identity`
+- `Sigmoid`
+- `ReLU`
+- `Tanh`
+
+By default, neurons use `Identity`. To create a neuron with a specific
+activation, either instantiate a [`Neuron`] directly or use
+`Network::add_neuron_with_activation`:
+
+```rust
+use aei_framework::{Activation, Neuron};
+
+let neuron = Neuron::new(1, Activation::Tanh);
 ```
 
 ## Development

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,0 +1,35 @@
+/// Defines activation functions available for neurons.
+///
+/// Each variant provides a mathematical transformation applied to the input
+/// value during propagation. More functions can be added in the future by
+/// extending this enum.
+#[derive(Debug, Clone, Copy)]
+pub enum Activation {
+    /// Returns the input unchanged.
+    Identity,
+    /// Logistic sigmoid: `1 / (1 + e^{-x})`.
+    Sigmoid,
+    /// Rectified Linear Unit: `max(0, x)`.
+    ReLU,
+    /// Hyperbolic tangent function.
+    Tanh,
+}
+
+impl Activation {
+    /// Applies the activation function to the provided value.
+    #[must_use]
+    pub fn apply(self, x: f64) -> f64 {
+        match self {
+            Activation::Identity => x,
+            Activation::Sigmoid => 1.0 / (1.0 + (-x).exp()),
+            Activation::ReLU => x.max(0.0),
+            Activation::Tanh => x.tanh(),
+        }
+    }
+}
+
+impl Default for Activation {
+    fn default() -> Self {
+        Activation::Identity
+    }
+}

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -3,9 +3,10 @@
 /// Each variant provides a mathematical transformation applied to the input
 /// value during propagation. More functions can be added in the future by
 /// extending this enum.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum Activation {
     /// Returns the input unchanged.
+    #[default]
     Identity,
     /// Logistic sigmoid: `1 / (1 + e^{-x})`.
     Sigmoid,
@@ -25,11 +26,5 @@ impl Activation {
             Activation::ReLU => x.max(0.0),
             Activation::Tanh => x.tanh(),
         }
-    }
-}
-
-impl Default for Activation {
-    fn default() -> Self {
-        Activation::Identity
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 //! Core of the AEI Framework, a Rust framework for building dynamic and
 //! modular neural networks.
 
+pub mod activation;
 pub mod network;
 pub mod neuron;
 pub mod synapse;
 
+pub use activation::Activation;
 pub use network::Network;
 pub use neuron::Neuron;
 pub use synapse::Synapse;

--- a/src/neuron.rs
+++ b/src/neuron.rs
@@ -1,27 +1,28 @@
-/// Represents a basic neuron within the network.
+use crate::Activation;
+
+/// Represents a neuron within the network.
 ///
-/// Each neuron has a unique identifier and a floating-point value
-/// representing its current state. The activation function used here is
-/// the identity: the neuron's value is returned unchanged.
+/// Each neuron has a unique identifier, an activation function and a
+/// floating-point value representing its current state.
 #[derive(Debug, Clone)]
 pub struct Neuron {
     /// Unique identifier of the neuron.
     pub id: usize,
-    /// Current value of the neuron.
+    /// Current output value of the neuron (after activation).
     pub value: f64,
+    /// Activation function used by this neuron.
+    pub activation: Activation,
 }
 
 impl Neuron {
-    /// Creates a new neuron with an initial value of `0.0`.
-    pub fn new(id: usize) -> Self {
-        Self { id, value: 0.0 }
-    }
-
-    /// Applies the neuron's activation function.
+    /// Creates a new neuron with the provided activation function.
     ///
-    /// For this MVP, activation is the identity and simply returns the
-    /// neuron's current value.
-    pub fn activation(&self) -> f64 {
-        self.value
+    /// The neuron starts with a value of `0.0`.
+    pub fn new(id: usize, activation: Activation) -> Self {
+        Self {
+            id,
+            value: 0.0,
+            activation,
+        }
     }
 }

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -1,6 +1,6 @@
-use aei_framework::Network;
+use aei_framework::{Activation, Network};
 
-/// Checks the propagation of a value through a simple network.
+/// Checks the propagation of a value through a network using the identity activation.
 #[test]
 fn simple_propagation() {
     let mut net = Network::new();
@@ -9,4 +9,39 @@ fn simple_propagation() {
     net.add_synapse(a, b, 0.5);
     net.propagate(a, 2.0);
     assert_eq!(net.value(b), Some(1.0));
+}
+
+/// Ensures the sigmoid activation is applied to the target neuron.
+#[test]
+fn sigmoid_activation() {
+    let mut net = Network::new();
+    let a = net.add_neuron();
+    let b = net.add_neuron_with_activation(Activation::Sigmoid);
+    net.add_synapse(a, b, 1.0);
+    net.propagate(a, 0.0);
+    let out = net.value(b).unwrap();
+    assert!((out - 0.5).abs() < 1e-6);
+}
+
+/// Ensures the ReLU activation is applied to the target neuron.
+#[test]
+fn relu_activation() {
+    let mut net = Network::new();
+    let a = net.add_neuron();
+    let b = net.add_neuron_with_activation(Activation::ReLU);
+    net.add_synapse(a, b, 1.0);
+    net.propagate(a, -1.0);
+    assert_eq!(net.value(b), Some(0.0));
+}
+
+/// Ensures the tanh activation is applied to the target neuron.
+#[test]
+fn tanh_activation() {
+    let mut net = Network::new();
+    let a = net.add_neuron();
+    let b = net.add_neuron_with_activation(Activation::Tanh);
+    net.add_synapse(a, b, 1.0);
+    net.propagate(a, 1.0);
+    let out = net.value(b).unwrap();
+    assert!((out - 1.0f64.tanh()).abs() < 1e-6);
 }


### PR DESCRIPTION
## Summary
- add extensible `Activation` enum
- allow neurons and networks to choose activation functions
- document activation options and provide examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6891fdafe1b88321ba348773eb6ff74a