### PR TITLE
Improve tests and documentation for network

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ use aei_framework::{Activation, Neuron};
 let neuron = Neuron::new(1, Activation::Tanh);
 ```
 
+## Example: Multi-Activation Network
+
+```rust
+use aei_framework::{activation::Activation, network::Network};
+
+let mut net = Network::new();
+let n1 = net.add_neuron_with_activation(Activation::Sigmoid);
+let n2 = net.add_neuron_with_activation(Activation::ReLU);
+net.add_synapse(n1, n2, 2.0);
+
+net.propagate(n1, 1.0);
+println!("Value of neuron {n1} (Sigmoid): {}", net.value(n1).unwrap());
+println!("Value of neuron {n2} (ReLU): {}", net.value(n2).unwrap());
+```
+
+Using varied activations lets each neuron process data differently. Combining
+smooth functions like `Sigmoid` with piecewise-linear ones like `ReLU` increases
+the representational power of the network.
+
 ## Propagation Flow
 
 `Network::propagate` performs a forward pass through the network in four

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -1,71 +1,71 @@
-use aei_framework::{Activation, Network};
+use aei_framework::{activation::Activation, network::Network};
 
-// Helper function for floating point comparisons.
+// Helper for floating-point comparisons in tests.
 fn approx_eq(a: f64, b: f64) -> bool {
-    (a - b).abs() < 1e-6
+    (a - b).abs() < 1e-8
 }
 
-/// Ensures propagation applies activations in order and resets neuron values
-/// between runs.
+/// Sigmoid source neuron connected to a ReLU target through a synapse with
+/// weight `2.0`.
 #[test]
-fn propagation_with_activation_and_reset() {
+fn test_sigmoid_to_relu_chain() {
     let mut net = Network::new();
-    let input = net.add_neuron_with_activation(Activation::Sigmoid);
-    let output = net.add_neuron_with_activation(Activation::ReLU);
-    net.add_synapse(input, output, 2.0);
+    let n1 = net.add_neuron_with_activation(Activation::Sigmoid);
+    let n2 = net.add_neuron_with_activation(Activation::ReLU);
+    net.add_synapse(n1, n2, 2.0);
 
-    // First propagation
-    net.propagate(input, 1.0);
-    let expected_in = Activation::Sigmoid.apply(1.0);
-    let expected_out = Activation::ReLU.apply(expected_in * 2.0);
-    assert!(approx_eq(net.value(input).unwrap(), expected_in));
-    assert!(approx_eq(net.value(output).unwrap(), expected_out));
+    net.propagate(n1, 1.0);
 
-    // Second propagation with a different value to ensure reset
-    net.propagate(input, 0.0);
-    let expected_in2 = Activation::Sigmoid.apply(0.0);
-    let expected_out2 = Activation::ReLU.apply(expected_in2 * 2.0);
-    assert!(approx_eq(net.value(input).unwrap(), expected_in2));
-    assert!(approx_eq(net.value(output).unwrap(), expected_out2));
+    let expected_n1 = 1.0 / (1.0 + (-1.0f64).exp());
+    let expected_n2 = (expected_n1 * 2.0).max(0.0);
+    assert!(approx_eq(net.value(n1).unwrap(), expected_n1));
+    assert!(approx_eq(net.value(n2).unwrap(), expected_n2));
 }
 
-/// Propagation where the source neuron uses ReLU and the target Identity.
+/// Propagating several values in sequence should not accumulate state between
+/// runs.
 #[test]
-fn propagation_with_relu_source() {
+fn test_multiple_propagations_reset() {
     let mut net = Network::new();
-    let input = net.add_neuron_with_activation(Activation::ReLU);
-    let output = net.add_neuron(); // Identity
-    net.add_synapse(input, output, 1.0);
+    let src = net.add_neuron_with_activation(Activation::Identity);
+    let dst = net.add_neuron_with_activation(Activation::Identity);
+    net.add_synapse(src, dst, 1.0);
 
-    net.propagate(input, -1.0);
-    assert_eq!(net.value(input), Some(0.0));
-    assert_eq!(net.value(output), Some(0.0));
+    for &v in &[1.0, -2.0, 0.5] {
+        net.propagate(src, v);
+        assert!(approx_eq(net.value(src).unwrap(), v));
+        assert!(approx_eq(net.value(dst).unwrap(), v));
+    }
 }
 
-/// Propagation where the source neuron uses Tanh.
+/// Propagating from a non-existent neuron should do nothing.
 #[test]
-fn propagation_with_tanh_source() {
+fn test_propagate_nonexistent_neuron() {
     let mut net = Network::new();
-    let input = net.add_neuron_with_activation(Activation::Tanh);
-    let output = net.add_neuron(); // Identity
-    net.add_synapse(input, output, 1.0);
+    let id = net.add_neuron();
 
-    net.propagate(input, 1.0);
-    let expected = Activation::Tanh.apply(1.0);
-    assert!(approx_eq(net.value(input).unwrap(), expected));
-    assert!(approx_eq(net.value(output).unwrap(), expected));
+    net.propagate(id + 1, 1.0);
+    assert!(approx_eq(net.value(id).unwrap(), 0.0));
 }
 
-/// Propagation where the target neuron uses Sigmoid.
+/// Synapses targeting missing neurons are ignored.
 #[test]
-fn propagation_with_sigmoid_target() {
+fn test_synapse_to_missing_neuron() {
     let mut net = Network::new();
-    let input = net.add_neuron(); // Identity
-    let output = net.add_neuron_with_activation(Activation::Sigmoid);
-    net.add_synapse(input, output, 1.0);
+    let src = net.add_neuron();
+    net.add_synapse(src, 999, 1.0);
 
-    net.propagate(input, 1.0);
-    let expected_out = Activation::Sigmoid.apply(1.0);
-    assert_eq!(net.value(input), Some(1.0));
-    assert!(approx_eq(net.value(output).unwrap(), expected_out));
+    net.propagate(src, 1.0);
+    assert!(approx_eq(net.value(src).unwrap(), 1.0));
+}
+
+/// Synapses whose source neuron is missing never fire.
+#[test]
+fn test_orphan_synapse() {
+    let mut net = Network::new();
+    let existing = net.add_neuron();
+    net.add_synapse(999, existing, 1.0);
+
+    net.propagate(existing, 2.0);
+    assert!(approx_eq(net.value(existing).unwrap(), 2.0));
 }


### PR DESCRIPTION
## Summary
- add integration tests covering activation chains, resets, and edge cases
- document `Network` and its `propagate` method
- expand README with multi-activation example

## Testing
- `cargo test`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68920651f0148321940487ef324a9aa8