### PR TITLE
Refine propagation and broaden activation coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Neuron`, `Synapse`, and `Network` structures
 - Propagation unit tests
 - Documentation and guides in English
+- Tests covering all activation functions and chained propagation
+### Changed
+- Propagation logic now applies activations after weighted sums and resets all
+  neuron values between runs.
+- Comprehensive rustdoc for modules and public APIs.
+- Neurons carry a `Uuid` preparing for global identifiers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ members = [
     "crates/utils",
 ]
 resolver = "2"
+
+[dependencies]
+uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,43 @@ fn main() {
 }
 ```
 
+## Advanced Example
+
+Create a small network with heterogeneous activations and observe the
+propagation of a value through the chain of neurons.
+
+```rust
+use aei_framework::{Activation, Network};
+
+let mut net = Network::new();
+let input = net.add_neuron_with_activation(Activation::Identity);
+let hidden = net.add_neuron_with_activation(Activation::ReLU);
+let output = net.add_neuron_with_activation(Activation::Tanh);
+net.add_synapse(input, hidden, 0.5);
+net.add_synapse(hidden, output, 1.0);
+
+// Propagate once from the input neuron.
+net.propagate(input, 1.0);
+
+println!("Hidden neuron value: {}", net.value(hidden).unwrap());
+println!("Output neuron value: {}", net.value(output).unwrap());
+```
+
+## Step-by-Step Propagation
+
+`Network::propagate` performs four ordered phases:
+
+1. **Reset** – every neuron's value is cleared to `0.0`.
+2. **Source activation** – the input value is passed through the source
+   neuron's activation function.
+3. **Weighted propagation** – synapses contribute `from_value * weight` to
+   their targets.
+4. **Activation** – each target neuron applies its activation function once all
+   inputs have been received.
+
+This deterministic sequence ensures that repeated calls do not accumulate
+state and that activations are applied only after all inputs are processed.
+
 ## Activation Functions
 
 Neurons support several activation functions:
@@ -101,3 +138,10 @@ See [CHANGELOG.md](CHANGELOG.md) for the list of changes.
 ## License
 
 Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for more information.
+
+## Known Limitations
+
+- Neuron identifiers are numeric and local to a network. Each neuron now also
+  stores a `Uuid` but it is not yet used as the primary key.
+- No persistence or serialization layer is currently provided.
+- Layered abstractions and neuron removal are planned but not implemented.

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,8 +1,8 @@
-/// Defines activation functions available for neurons.
-///
-/// Each variant provides a mathematical transformation applied to the input
-/// value during propagation. More functions can be added in the future by
-/// extending this enum.
+//! Activation functions available for neurons.
+//!
+//! Each variant provides a mathematical transformation applied to the input
+//! value during propagation. More functions can be added in the future by
+//! extending this enum.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum Activation {
     /// Returns the input unchanged.

--- a/src/neuron.rs
+++ b/src/neuron.rs
@@ -1,4 +1,7 @@
+//! Representation of neurons within a [`Network`].
+
 use crate::Activation;
+use uuid::Uuid;
 
 /// Represents a neuron within the network.
 ///
@@ -8,6 +11,11 @@ use crate::Activation;
 pub struct Neuron {
     /// Unique identifier of the neuron.
     pub id: usize,
+    /// Globally unique identifier.
+    ///
+    /// TODO: replace `id` usages with this `uuid` to avoid collisions and to
+    /// support serialization across processes.
+    pub uuid: Uuid,
     /// Current output value of the neuron (after activation).
     pub value: f64,
     /// Activation function used by this neuron.
@@ -21,6 +29,7 @@ impl Neuron {
     pub fn new(id: usize, activation: Activation) -> Self {
         Self {
             id,
+            uuid: Uuid::new_v4(),
             value: 0.0,
             activation,
         }

--- a/src/synapse.rs
+++ b/src/synapse.rs
@@ -1,7 +1,7 @@
-/// Represents a synapse connecting two neurons.
-///
-/// A synapse carries the value from a source neuron to a target neuron,
-/// multiplying it by a weight.
+//! Synapse connecting two neurons.
+//!
+//! A synapse carries the value from a source neuron to a target neuron,
+//! multiplying it by a weight.
 #[derive(Debug, Clone)]
 pub struct Synapse {
     /// Identifier of the source neuron.

--- a/tests/activation_coverage.rs
+++ b/tests/activation_coverage.rs
@@ -1,0 +1,65 @@
+use aei_framework::{activation::Activation, network::Network};
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-8
+}
+
+#[test]
+fn test_all_activation_functions() {
+    let mut net = Network::new();
+    let id = net.add_neuron_with_activation(Activation::Identity);
+    let sigmoid = net.add_neuron_with_activation(Activation::Sigmoid);
+    let relu = net.add_neuron_with_activation(Activation::ReLU);
+    let tanh = net.add_neuron_with_activation(Activation::Tanh);
+
+    net.propagate(id, 0.5);
+    assert!(approx_eq(net.value(id).unwrap(), 0.5));
+
+    net.propagate(sigmoid, 1.0);
+    let expected_sigmoid = 1.0 / (1.0 + (-1.0f64).exp());
+    assert!(approx_eq(net.value(sigmoid).unwrap(), expected_sigmoid));
+
+    net.propagate(relu, -2.0);
+    assert!(approx_eq(net.value(relu).unwrap(), 0.0));
+
+    net.propagate(tanh, 1.0);
+    assert!(approx_eq(net.value(tanh).unwrap(), 1.0f64.tanh()));
+}
+
+#[test]
+fn test_chained_propagation() {
+    let mut net = Network::new();
+    let a = net.add_neuron_with_activation(Activation::Sigmoid);
+    let b = net.add_neuron_with_activation(Activation::ReLU);
+    let c = net.add_neuron_with_activation(Activation::Tanh);
+    net.add_synapse(a, b, 2.0);
+    net.add_synapse(b, c, -1.0);
+
+    net.propagate(a, 1.0);
+
+    let expected_a = 1.0 / (1.0 + (-1.0f64).exp());
+    let expected_b = (expected_a * 2.0).max(0.0);
+    let expected_c = (expected_b * -1.0).tanh();
+
+    assert!(approx_eq(net.value(a).unwrap(), expected_a));
+    assert!(approx_eq(net.value(b).unwrap(), expected_b));
+    assert!(approx_eq(net.value(c).unwrap(), expected_c));
+}
+
+#[test]
+fn test_no_accumulation() {
+    let mut net = Network::new();
+    let a = net.add_neuron_with_activation(Activation::Sigmoid);
+    let b = net.add_neuron_with_activation(Activation::ReLU);
+    net.add_synapse(a, b, 1.5);
+
+    net.propagate(a, 1.0);
+    let first_b = net.value(b).unwrap();
+
+    net.propagate(a, 0.5);
+    let second_expected_a = 1.0 / (1.0 + (-0.5f64).exp());
+    let second_expected_b = (second_expected_a * 1.5).max(0.0);
+
+    assert!(approx_eq(net.value(b).unwrap(), second_expected_b));
+    assert_ne!(first_b, net.value(b).unwrap());
+}


### PR DESCRIPTION
## Summary
- apply activations after weighted sums and reset neuron state each propagation
- add UUID field for neurons and expand documentation/examples
- test every activation and chained propagation with no value accumulation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68920a9d2c5883218fb521f89c3772ae