### PR TITLE
feat: add named inputs and outputs API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Propagation unit tests
 - Documentation and guides in English
 - Tests covering all activation functions and chained propagation
+- Named input/output neurons with high-level `set_inputs`, `get_outputs`, and
+  `propagate_inputs` APIs
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ println!("Hidden neuron value: {}", net.value(hidden).unwrap());
 println!("Output neuron value: {}", net.value(output).unwrap());
 ```
 
+## Named Inputs and Outputs
+
+Explicitly assign neurons as inputs or outputs and interact with them by name:
+
+```rust
+use aei_framework::{Activation, Network};
+
+let mut net = Network::new();
+let a = net.add_input_neuron("a", Activation::Identity);
+let b = net.add_input_neuron("b", Activation::Identity);
+let out = net.add_output_neuron("out", Activation::Sigmoid);
+net.add_synapse(a, out, 1.0);
+net.add_synapse(b, out, 1.0);
+
+net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
+net.propagate_inputs();
+let result = net.get_outputs();
+println!("Result: {:?}", result.get("out"));
+```
+
 ## Learning XOR
 
 Train a small network to approximate the XOR truth table using

--- a/tests/io_api.rs
+++ b/tests/io_api.rs
@@ -1,0 +1,46 @@
+use aei_framework::{activation::Activation, network::Network};
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-8
+}
+
+#[test]
+fn test_named_inputs_outputs() {
+    let mut net = Network::new();
+    let a = net.add_input_neuron("a", Activation::Identity);
+    let b = net.add_input_neuron("b", Activation::Identity);
+    let out = net.add_output_neuron("sum", Activation::Identity);
+    net.add_synapse(a, out, 1.0);
+    net.add_synapse(b, out, 1.0);
+
+    net.set_inputs(&[("a", 1.0), ("b", 2.0)]);
+    net.propagate_inputs();
+    let outputs = net.get_outputs();
+    assert!(approx_eq(outputs["sum"], 3.0));
+}
+
+#[test]
+fn test_indexed_inputs_outputs() {
+    let mut net = Network::new();
+    let a = net.add_input_neuron("a", Activation::Identity);
+    let b = net.add_input_neuron("b", Activation::Identity);
+    let out = net.add_output_neuron("sum", Activation::Identity);
+    net.add_synapse(a, out, 1.0);
+    net.add_synapse(b, out, 1.0);
+
+    net.set_inputs_by_index(&[1.0, 2.0]);
+    net.propagate_inputs();
+    let outputs = net.get_outputs_by_index();
+    assert!(approx_eq(outputs[0], 3.0));
+}
+
+#[test]
+fn test_backward_compatibility_by_id() {
+    let mut net = Network::new();
+    let input = net.add_input_neuron("in", Activation::Identity);
+    let output = net.add_output_neuron("out", Activation::Identity);
+    net.add_synapse(input, output, 1.0);
+
+    net.propagate(input, 2.0);
+    assert!(approx_eq(net.value(output).unwrap(), 2.0));
+}


### PR DESCRIPTION
## Summary
- allow registering neurons as named inputs and outputs
- add high level API to set input values and read outputs via names or indices
- document usage and cover with tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6892f8ab19308321b49010aec76b2b5f