### PR TITLE
Use UUID identifiers for network elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.
 - Comprehensive rustdoc for modules and public APIs.
-- Neurons carry a `Uuid` preparing for global identifiers.
+- Neuron and synapse identifiers now use `Uuid` instead of numeric indexes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ members = [
 resolver = "2"
 
 [dependencies]
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1.8", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Identifiers
+
+Every neuron and synapse receives a random [`Uuid`](https://docs.rs/uuid) when
+created. These globally unique identifiers improve serialization and allow
+merging networks without collisions. Constructors such as
+`Neuron::with_id` and `Network::add_neuron_with_id` let you supply explicit
+identifiers if needed:
+
+```rust
+use aei_framework::{Activation, Neuron};
+use uuid::Uuid;
+
+let id = Uuid::new_v4();
+let neuron = Neuron::with_id(id, Activation::Sigmoid);
+println!("Neuron {id} has value {}", neuron.value);
+```
+
 ## Learning XOR
 
 Train a small network to approximate the XOR truth table using
@@ -136,7 +153,8 @@ activation, either instantiate a [`Neuron`] directly or use
 ```rust
 use aei_framework::{Activation, Neuron};
 
-let neuron = Neuron::new(1, Activation::Tanh);
+let neuron = Neuron::new(Activation::Tanh);
+println!("Neuron id: {}", neuron.id);
 ```
 
 ## Example: Multi-Activation Network
@@ -196,7 +214,7 @@ Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for mor
 
 ## Known Limitations
 
-- Neuron identifiers are numeric and local to a network. Each neuron now also
-  stores a `Uuid` but it is not yet used as the primary key.
+- Neuron and synapse identifiers use `Uuid`. Networks serialized with older
+  numeric identifiers are not supported.
 - No persistence or serialization layer is currently provided.
 - Layered abstractions and neuron removal are planned but not implemented.

--- a/src/neuron.rs
+++ b/src/neuron.rs
@@ -9,13 +9,8 @@ use uuid::Uuid;
 /// floating-point value representing its current state.
 #[derive(Debug, Clone)]
 pub struct Neuron {
-    /// Unique identifier of the neuron.
-    pub id: usize,
-    /// Globally unique identifier.
-    ///
-    /// TODO: replace `id` usages with this `uuid` to avoid collisions and to
-    /// support serialization across processes.
-    pub uuid: Uuid,
+    /// Globally unique identifier of the neuron.
+    pub id: Uuid,
     /// Current output value of the neuron (after activation).
     pub value: f64,
     /// Activation function used by this neuron.
@@ -23,13 +18,20 @@ pub struct Neuron {
 }
 
 impl Neuron {
-    /// Creates a new neuron with the provided activation function.
-    ///
-    /// The neuron starts with a value of `0.0`.
-    pub fn new(id: usize, activation: Activation) -> Self {
+    /// Creates a new neuron with the provided activation function and a fresh
+    /// random [`Uuid`].
+    pub fn new(activation: Activation) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            value: 0.0,
+            activation,
+        }
+    }
+
+    /// Creates a neuron using the supplied [`Uuid`].
+    pub fn with_id(id: Uuid, activation: Activation) -> Self {
         Self {
             id,
-            uuid: Uuid::new_v4(),
             value: 0.0,
             activation,
         }

--- a/src/synapse.rs
+++ b/src/synapse.rs
@@ -2,19 +2,39 @@
 //!
 //! A synapse carries the value from a source neuron to a target neuron,
 //! multiplying it by a weight.
+
+use uuid::Uuid;
+
 #[derive(Debug, Clone)]
 pub struct Synapse {
+    /// Globally unique identifier of the synapse.
+    pub id: Uuid,
     /// Identifier of the source neuron.
-    pub from: usize,
+    pub from: Uuid,
     /// Identifier of the target neuron.
-    pub to: usize,
+    pub to: Uuid,
     /// Weight applied during propagation.
     pub weight: f64,
 }
 
 impl Synapse {
-    /// Creates a new directed synapse.
-    pub fn new(from: usize, to: usize, weight: f64) -> Self {
-        Self { from, to, weight }
+    /// Creates a new directed synapse with a random [`Uuid`].
+    pub fn new(from: Uuid, to: Uuid, weight: f64) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            from,
+            to,
+            weight,
+        }
+    }
+
+    /// Creates a synapse using the supplied [`Uuid`].
+    pub fn with_id(id: Uuid, from: Uuid, to: Uuid, weight: f64) -> Self {
+        Self {
+            id,
+            from,
+            to,
+            weight,
+        }
     }
 }

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -1,4 +1,5 @@
 use aei_framework::{activation::Activation, network::Network};
+use uuid::Uuid;
 
 // Helper for floating-point comparisons in tests.
 fn approx_eq(a: f64, b: f64) -> bool {
@@ -44,7 +45,7 @@ fn test_propagate_nonexistent_neuron() {
     let mut net = Network::new();
     let id = net.add_neuron();
 
-    net.propagate(id + 1, 1.0);
+    net.propagate(Uuid::new_v4(), 1.0);
     assert!(approx_eq(net.value(id).unwrap(), 0.0));
 }
 
@@ -53,7 +54,7 @@ fn test_propagate_nonexistent_neuron() {
 fn test_synapse_to_missing_neuron() {
     let mut net = Network::new();
     let src = net.add_neuron();
-    net.add_synapse(src, 999, 1.0);
+    net.add_synapse(src, Uuid::new_v4(), 1.0);
 
     net.propagate(src, 1.0);
     assert!(approx_eq(net.value(src).unwrap(), 1.0));
@@ -64,8 +65,18 @@ fn test_synapse_to_missing_neuron() {
 fn test_orphan_synapse() {
     let mut net = Network::new();
     let existing = net.add_neuron();
-    net.add_synapse(999, existing, 1.0);
+    net.add_synapse(Uuid::new_v4(), existing, 1.0);
 
     net.propagate(existing, 2.0);
     assert!(approx_eq(net.value(existing).unwrap(), 2.0));
+}
+
+/// Neuron identifiers remain stable through string serialization.
+#[test]
+fn test_uuid_round_trip() {
+    let mut net = Network::new();
+    let id = net.add_neuron();
+    let s = id.to_string();
+    let parsed = Uuid::parse_str(&s).unwrap();
+    assert_eq!(id, parsed);
 }


### PR DESCRIPTION
## Summary
- switch neuron and synapse identifiers to `Uuid`
- adapt `Network` to manage neurons and synapses by UUID with helper constructors
- document UUID identifiers and update tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6892faca926c83218650a567fd6790f3