### PR TITLE
Add JSON serialization for networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests covering all activation functions and chained propagation
 - Named input/output neurons with high-level `set_inputs`, `get_outputs`, and
   `propagate_inputs` APIs
+- JSON serialization and loading for networks via `save_json` and `load_json`
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,6 @@ members = [
 resolver = "2"
 
 [dependencies]
-uuid = { version = "1.8", features = ["v4"] }
+uuid = { version = "1.8", features = ["v4", "serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Serialization
+
+Persist networks to disk and load them back later using JSON:
+
+```rust
+use aei_framework::{Activation, Network};
+use std::path::Path;
+
+let mut net = Network::new();
+let a = net.add_input_neuron("a", Activation::Identity);
+let b = net.add_output_neuron("b", Activation::Identity);
+net.add_synapse(a, b, 1.0);
+
+let path = Path::new("network.json");
+net.save_json(path).unwrap();
+let restored = Network::load_json(path).unwrap();
+```
+
 ## Identifiers
 
 Every neuron and synapse receives a random [`Uuid`](https://docs.rs/uuid) when
@@ -233,5 +251,5 @@ Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for mor
 
 - Neuron and synapse identifiers use `Uuid`. Networks serialized with older
   numeric identifiers are not supported.
-- No persistence or serialization layer is currently provided.
+- JSON persistence is available via `save_json` and `load_json`.
 - Layered abstractions and neuron removal are planned but not implemented.

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests covering all activation functions and chained propagation
 - Named input/output neurons with high-level `set_inputs`, `get_outputs`, and
   `propagate_inputs` APIs
+- JSON serialization and loading for networks via `save_json` and `load_json`
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -70,6 +70,24 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Serialization
+
+Persist networks to disk and load them back later using JSON:
+
+```rust
+use aei_framework::{Activation, Network};
+use std::path::Path;
+
+let mut net = Network::new();
+let a = net.add_input_neuron("a", Activation::Identity);
+let b = net.add_output_neuron("b", Activation::Identity);
+net.add_synapse(a, b, 1.0);
+
+let path = Path::new("network.json");
+net.save_json(path).unwrap();
+let restored = Network::load_json(path).unwrap();
+```
+
 ## Identifiers
 
 Every neuron and synapse receives a random [`Uuid`](https://docs.rs/uuid) when
@@ -233,5 +251,5 @@ Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for mor
 
 - Neuron and synapse identifiers use `Uuid`. Networks serialized with older
   numeric identifiers are not supported.
-- No persistence or serialization layer is currently provided.
+- JSON persistence is available via `save_json` and `load_json`.
 - Layered abstractions and neuron removal are planned but not implemented.

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -19,6 +19,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Documentation et guides en anglais
 - Tests couvrant toutes les fonctions d'activation et la propagation chaînée
 - Neurones d'entrée/sortie nommés avec les API de haut niveau `set_inputs`, `get_outputs` et `propagate_inputs`
+- Sérialisation et chargement JSON des réseaux via `save_json` et `load_json`
 ### Modifié
 - La logique de propagation applique désormais les activations après les sommes pondérées et réinitialise toutes les valeurs des neurones entre les exécutions.
 - Rustdoc complet pour les modules et les API publiques.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -70,6 +70,24 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Sérialisation
+
+Persistez les réseaux sur disque et rechargez-les ensuite en JSON :
+
+```rust
+use aei_framework::{Activation, Network};
+use std::path::Path;
+
+let mut net = Network::new();
+let a = net.add_input_neuron("a", Activation::Identity);
+let b = net.add_output_neuron("b", Activation::Identity);
+net.add_synapse(a, b, 1.0);
+
+let path = Path::new("network.json");
+net.save_json(path).unwrap();
+let restored = Network::load_json(path).unwrap();
+```
+
 ## Identificateurs
 
 Chaque neurone et synapse reçoit un [`uuid`] aléatoire (https://docs.rs/uuid) quand
@@ -231,7 +249,6 @@ Distribué sous la licence publique de Mozilla 2.0.
 
 ## Limitations connues
 
-- Les identificateurs de neurones et de synapses utilisent «uuid». 
-Les identifiants numériques ne sont pas pris en charge.
-- Aucune couche de persistance ou de sérialisation n'est actuellement fournie.
+- Les identificateurs de neurones et de synapses utilisent `Uuid`. Les réseaux sérialisés avec d'anciens identifiants numériques ne sont pas pris en charge.
+- La persistance JSON est disponible via `save_json` et `load_json`.
 - Les abstractions en couches et l'élimination des neurones sont planifiées mais non mises en œuvre.

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -50,15 +50,13 @@ impl Network {
     /// Saves the network as pretty JSON to the specified file path.
     pub fn save_json<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let file = File::create(path)?;
-        serde_json::to_writer_pretty(file, self)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        serde_json::to_writer_pretty(file, self).map_err(io::Error::other)
     }
 
     /// Loads a network from a JSON file created by [`save_json`].
     pub fn load_json<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = File::open(path)?;
-        let mut net: Network =
-            serde_json::from_reader(file).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let mut net: Network = serde_json::from_reader(file).map_err(io::Error::other)?;
         net.rebuild_indices();
         Ok(net)
     }

--- a/src/core/activation.rs
+++ b/src/core/activation.rs
@@ -3,7 +3,9 @@
 //! Each variant provides a mathematical transformation applied to the input
 //! value during propagation. More functions can be added in the future by
 //! extending this enum.
-#[derive(Debug, Clone, Copy, Default)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub enum Activation {
     /// Returns the input unchanged.
     #[default]

--- a/src/core/neuron.rs
+++ b/src/core/neuron.rs
@@ -1,13 +1,14 @@
 //! Representation of neurons within a [`Network`].
 
 use crate::Activation;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Represents a neuron within the network.
 ///
 /// Each neuron has a unique identifier, an activation function and a
 /// floating-point value representing its current state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Neuron {
     /// Globally unique identifier of the neuron.
     pub id: Uuid,

--- a/src/core/synapse.rs
+++ b/src/core/synapse.rs
@@ -3,9 +3,10 @@
 //! A synapse carries the value from a source neuron to a target neuron,
 //! multiplying it by a weight.
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Synapse {
     /// Globally unique identifier of the synapse.
     pub id: Uuid,

--- a/tests/basic_integration.rs
+++ b/tests/basic_integration.rs
@@ -1,5 +1,0 @@
-/// Basic test to ensure the test environment works.
-#[test]
-fn framework_compiles() {
-    assert_eq!(2 + 2, 4);
-}

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -1,0 +1,22 @@
+use aei_framework::{Activation, Network};
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn network_json_roundtrip() {
+    let mut net = Network::new();
+    let inp = net.add_input_neuron("in", Activation::Identity);
+    let out = net.add_output_neuron("out", Activation::Identity);
+    net.add_synapse(inp, out, 1.5);
+
+    let path = Path::new("/tmp/net.json");
+    net.save_json(path).unwrap();
+
+    let mut loaded = Network::load_json(path).unwrap();
+    fs::remove_file(path).ok();
+
+    loaded.set_inputs(&[("in", 2.0)]);
+    loaded.propagate_inputs();
+    let outputs = loaded.get_outputs();
+    assert_eq!(outputs.get("out").copied().unwrap(), 3.0);
+}

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -1,6 +1,5 @@
 use aei_framework::{Activation, Network};
 use std::fs;
-use std::path::Path;
 
 #[test]
 fn network_json_roundtrip() {
@@ -9,11 +8,12 @@ fn network_json_roundtrip() {
     let out = net.add_output_neuron("out", Activation::Identity);
     net.add_synapse(inp, out, 1.5);
 
-    let path = Path::new("/tmp/net.json");
-    net.save_json(path).unwrap();
+    let mut path = std::env::temp_dir();
+    path.push("net.json");
+    net.save_json(&path).unwrap();
 
-    let mut loaded = Network::load_json(path).unwrap();
-    fs::remove_file(path).ok();
+    let mut loaded = Network::load_json(&path).unwrap();
+    fs::remove_file(&path).ok();
 
     loaded.set_inputs(&[("in", 2.0)]);
     loaded.propagate_inputs();


### PR DESCRIPTION
## Summary
- derive Serde support for core types and network
- add `save_json`/`load_json` helpers for persisting networks
- document and test JSON roundtrips

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68930c920ae483218104b8f646f97c34