### PR TITLE
Return Result for synapse creation and handle unknown neurons

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ fn main() {
     let input = net.add_neuron(); // Uses the default identity activation
     let hidden = net.add_neuron_with_activation(Activation::ReLU);
     let output = net.add_neuron_with_activation(Activation::Sigmoid);
-    net.add_synapse(input, hidden, 1.0);
-    net.add_synapse(hidden, output, 1.0);
+    net.add_synapse(input, hidden, 1.0).unwrap();
+    net.add_synapse(hidden, output, 1.0).unwrap();
     net.propagate(input, -0.5);
     println!("Value of output neuron: {:?}", net.value(output));
 }
@@ -40,8 +40,8 @@ let mut net = Network::new();
 let input = net.add_neuron_with_activation(Activation::Identity);
 let hidden = net.add_neuron_with_activation(Activation::ReLU);
 let output = net.add_neuron_with_activation(Activation::Tanh);
-net.add_synapse(input, hidden, 0.5);
-net.add_synapse(hidden, output, 1.0);
+net.add_synapse(input, hidden, 0.5).unwrap();
+net.add_synapse(hidden, output, 1.0).unwrap();
 
 // Propagate once from the input neuron.
 net.propagate(input, 1.0);
@@ -61,8 +61,8 @@ let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_input_neuron("b", Activation::Identity);
 let out = net.add_output_neuron("out", Activation::Sigmoid);
-net.add_synapse(a, out, 1.0);
-net.add_synapse(b, out, 1.0);
+net.add_synapse(a, out, 1.0).unwrap();
+net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
 net.propagate_inputs();
@@ -81,7 +81,7 @@ use std::path::Path;
 let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_output_neuron("b", Activation::Identity);
-net.add_synapse(a, b, 1.0);
+net.add_synapse(a, b, 1.0).unwrap();
 
 let path = Path::new("network.json");
 net.save_json(path).unwrap();
@@ -120,12 +120,12 @@ let h1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let h2 = net.add_neuron_with_activation(Activation::Sigmoid);
 let o = net.add_neuron_with_activation(Activation::Sigmoid);
 
-net.add_synapse(i1, h1, 0.5);
-net.add_synapse(i1, h2, -0.5);
-net.add_synapse(i2, h1, -0.5);
-net.add_synapse(i2, h2, 0.5);
-net.add_synapse(h1, o, 0.5);
-net.add_synapse(h2, o, 0.5);
+net.add_synapse(i1, h1, 0.5).unwrap();
+net.add_synapse(i1, h2, -0.5).unwrap();
+net.add_synapse(i2, h1, -0.5).unwrap();
+net.add_synapse(i2, h2, 0.5).unwrap();
+net.add_synapse(h1, o, 0.5).unwrap();
+net.add_synapse(h2, o, 0.5).unwrap();
 
 let dataset = [
     (vec![0.0, 0.0], vec![0.0]),
@@ -183,7 +183,7 @@ use aei_framework::{Activation, Network};
 let mut net = Network::new();
 let n1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let n2 = net.add_neuron_with_activation(Activation::ReLU);
-net.add_synapse(n1, n2, 2.0);
+net.add_synapse(n1, n2, 2.0).unwrap();
 
 net.propagate(n1, 1.0);
 println!("Value of neuron {n1} (Sigmoid): {}", net.value(n1).unwrap());

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -21,8 +21,8 @@ fn main() {
     let input = net.add_neuron(); // Uses the default identity activation
     let hidden = net.add_neuron_with_activation(Activation::ReLU);
     let output = net.add_neuron_with_activation(Activation::Sigmoid);
-    net.add_synapse(input, hidden, 1.0);
-    net.add_synapse(hidden, output, 1.0);
+    net.add_synapse(input, hidden, 1.0).unwrap();
+    net.add_synapse(hidden, output, 1.0).unwrap();
     net.propagate(input, -0.5);
     println!("Value of output neuron: {:?}", net.value(output));
 }
@@ -40,8 +40,8 @@ let mut net = Network::new();
 let input = net.add_neuron_with_activation(Activation::Identity);
 let hidden = net.add_neuron_with_activation(Activation::ReLU);
 let output = net.add_neuron_with_activation(Activation::Tanh);
-net.add_synapse(input, hidden, 0.5);
-net.add_synapse(hidden, output, 1.0);
+net.add_synapse(input, hidden, 0.5).unwrap();
+net.add_synapse(hidden, output, 1.0).unwrap();
 
 // Propagate once from the input neuron.
 net.propagate(input, 1.0);
@@ -61,8 +61,8 @@ let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_input_neuron("b", Activation::Identity);
 let out = net.add_output_neuron("out", Activation::Sigmoid);
-net.add_synapse(a, out, 1.0);
-net.add_synapse(b, out, 1.0);
+net.add_synapse(a, out, 1.0).unwrap();
+net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
 net.propagate_inputs();
@@ -81,7 +81,7 @@ use std::path::Path;
 let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_output_neuron("b", Activation::Identity);
-net.add_synapse(a, b, 1.0);
+net.add_synapse(a, b, 1.0).unwrap();
 
 let path = Path::new("network.json");
 net.save_json(path).unwrap();
@@ -120,12 +120,12 @@ let h1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let h2 = net.add_neuron_with_activation(Activation::Sigmoid);
 let o = net.add_neuron_with_activation(Activation::Sigmoid);
 
-net.add_synapse(i1, h1, 0.5);
-net.add_synapse(i1, h2, -0.5);
-net.add_synapse(i2, h1, -0.5);
-net.add_synapse(i2, h2, 0.5);
-net.add_synapse(h1, o, 0.5);
-net.add_synapse(h2, o, 0.5);
+net.add_synapse(i1, h1, 0.5).unwrap();
+net.add_synapse(i1, h2, -0.5).unwrap();
+net.add_synapse(i2, h1, -0.5).unwrap();
+net.add_synapse(i2, h2, 0.5).unwrap();
+net.add_synapse(h1, o, 0.5).unwrap();
+net.add_synapse(h2, o, 0.5).unwrap();
 
 let dataset = [
     (vec![0.0, 0.0], vec![0.0]),
@@ -183,7 +183,7 @@ use aei_framework::{Activation, Network};
 let mut net = Network::new();
 let n1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let n2 = net.add_neuron_with_activation(Activation::ReLU);
-net.add_synapse(n1, n2, 2.0);
+net.add_synapse(n1, n2, 2.0).unwrap();
 
 net.propagate(n1, 1.0);
 println!("Value of neuron {n1} (Sigmoid): {}", net.value(n1).unwrap());

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -21,8 +21,8 @@ fn main() {
     let input = net.add_neuron(); // Uses the default identity activation
     let hidden = net.add_neuron_with_activation(Activation::ReLU);
     let output = net.add_neuron_with_activation(Activation::Sigmoid);
-    net.add_synapse(input, hidden, 1.0);
-    net.add_synapse(hidden, output, 1.0);
+    net.add_synapse(input, hidden, 1.0).unwrap();
+    net.add_synapse(hidden, output, 1.0).unwrap();
     net.propagate(input, -0.5);
     println!("Value of output neuron: {:?}", net.value(output));
 }
@@ -40,8 +40,8 @@ let mut net = Network::new();
 let input = net.add_neuron_with_activation(Activation::Identity);
 let hidden = net.add_neuron_with_activation(Activation::ReLU);
 let output = net.add_neuron_with_activation(Activation::Tanh);
-net.add_synapse(input, hidden, 0.5);
-net.add_synapse(hidden, output, 1.0);
+net.add_synapse(input, hidden, 0.5).unwrap();
+net.add_synapse(hidden, output, 1.0).unwrap();
 
 // Propagate once from the input neuron.
 net.propagate(input, 1.0);
@@ -61,8 +61,8 @@ let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_input_neuron("b", Activation::Identity);
 let out = net.add_output_neuron("out", Activation::Sigmoid);
-net.add_synapse(a, out, 1.0);
-net.add_synapse(b, out, 1.0);
+net.add_synapse(a, out, 1.0).unwrap();
+net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
 net.propagate_inputs();
@@ -81,7 +81,7 @@ use std::path::Path;
 let mut net = Network::new();
 let a = net.add_input_neuron("a", Activation::Identity);
 let b = net.add_output_neuron("b", Activation::Identity);
-net.add_synapse(a, b, 1.0);
+net.add_synapse(a, b, 1.0).unwrap();
 
 let path = Path::new("network.json");
 net.save_json(path).unwrap();
@@ -120,12 +120,12 @@ let h1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let h2 = net.add_neuron_with_activation(Activation::Sigmoid);
 let o = net.add_neuron_with_activation(Activation::Sigmoid);
 
-net.add_synapse(i1, h1, 0.5);
-net.add_synapse(i1, h2, -0.5);
-net.add_synapse(i2, h1, -0.5);
-net.add_synapse(i2, h2, 0.5);
-net.add_synapse(h1, o, 0.5);
-net.add_synapse(h2, o, 0.5);
+net.add_synapse(i1, h1, 0.5).unwrap();
+net.add_synapse(i1, h2, -0.5).unwrap();
+net.add_synapse(i2, h1, -0.5).unwrap();
+net.add_synapse(i2, h2, 0.5).unwrap();
+net.add_synapse(h1, o, 0.5).unwrap();
+net.add_synapse(h2, o, 0.5).unwrap();
 
 let dataset = [
     (vec![0.0, 0.0], vec![0.0]),
@@ -183,7 +183,7 @@ use aei_framework::{Activation, Network};
 let mut net = Network::new();
 let n1 = net.add_neuron_with_activation(Activation::Sigmoid);
 let n2 = net.add_neuron_with_activation(Activation::ReLU);
-net.add_synapse(n1, n2, 2.0);
+net.add_synapse(n1, n2, 2.0).unwrap();
 
 net.propagate(n1, 1.0);
 println!("Value of neuron {n1} (Sigmoid): {}", net.value(n1).unwrap());

--- a/examples/xor.rs
+++ b/examples/xor.rs
@@ -8,12 +8,12 @@ fn main() {
     let h2 = net.add_neuron_with_activation(Activation::Sigmoid);
     let o = net.add_neuron_with_activation(Activation::Sigmoid);
 
-    net.add_synapse(i1, h1, 0.5);
-    net.add_synapse(i1, h2, -0.5);
-    net.add_synapse(i2, h1, -0.5);
-    net.add_synapse(i2, h2, 0.5);
-    net.add_synapse(h1, o, 0.5);
-    net.add_synapse(h2, o, 0.5);
+    net.add_synapse(i1, h1, 0.5).unwrap();
+    net.add_synapse(i1, h2, -0.5).unwrap();
+    net.add_synapse(i2, h1, -0.5).unwrap();
+    net.add_synapse(i2, h2, 0.5).unwrap();
+    net.add_synapse(h1, o, 0.5).unwrap();
+    net.add_synapse(h2, o, 0.5).unwrap();
 
     let dataset = [
         (vec![0.0, 0.0], vec![0.0]),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,4 +2,4 @@
 
 mod network;
 
-pub use network::Network;
+pub use network::{Network, NetworkError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,5 @@
 pub mod api;
 pub mod core;
 
-pub use api::Network;
+pub use api::{Network, NetworkError};
 pub use core::{Activation, Neuron, Synapse};

--- a/tests/activation_coverage.rs
+++ b/tests/activation_coverage.rs
@@ -32,8 +32,8 @@ fn test_chained_propagation() {
     let a = net.add_neuron_with_activation(Activation::Sigmoid);
     let b = net.add_neuron_with_activation(Activation::ReLU);
     let c = net.add_neuron_with_activation(Activation::Tanh);
-    net.add_synapse(a, b, 2.0);
-    net.add_synapse(b, c, -1.0);
+    net.add_synapse(a, b, 2.0).unwrap();
+    net.add_synapse(b, c, -1.0).unwrap();
 
     net.propagate(a, 1.0);
 
@@ -51,7 +51,7 @@ fn test_no_accumulation() {
     let mut net = Network::new();
     let a = net.add_neuron_with_activation(Activation::Sigmoid);
     let b = net.add_neuron_with_activation(Activation::ReLU);
-    net.add_synapse(a, b, 1.5);
+    net.add_synapse(a, b, 1.5).unwrap();
 
     net.propagate(a, 1.0);
     let first_b = net.value(b).unwrap();

--- a/tests/io_api.rs
+++ b/tests/io_api.rs
@@ -10,8 +10,8 @@ fn test_named_inputs_outputs() {
     let a = net.add_input_neuron("a", Activation::Identity);
     let b = net.add_input_neuron("b", Activation::Identity);
     let out = net.add_output_neuron("sum", Activation::Identity);
-    net.add_synapse(a, out, 1.0);
-    net.add_synapse(b, out, 1.0);
+    net.add_synapse(a, out, 1.0).unwrap();
+    net.add_synapse(b, out, 1.0).unwrap();
 
     net.set_inputs(&[("a", 1.0), ("b", 2.0)]);
     net.propagate_inputs();
@@ -25,8 +25,8 @@ fn test_indexed_inputs_outputs() {
     let a = net.add_input_neuron("a", Activation::Identity);
     let b = net.add_input_neuron("b", Activation::Identity);
     let out = net.add_output_neuron("sum", Activation::Identity);
-    net.add_synapse(a, out, 1.0);
-    net.add_synapse(b, out, 1.0);
+    net.add_synapse(a, out, 1.0).unwrap();
+    net.add_synapse(b, out, 1.0).unwrap();
 
     net.set_inputs_by_index(&[1.0, 2.0]);
     net.propagate_inputs();
@@ -39,7 +39,7 @@ fn test_backward_compatibility_by_id() {
     let mut net = Network::new();
     let input = net.add_input_neuron("in", Activation::Identity);
     let output = net.add_output_neuron("out", Activation::Identity);
-    net.add_synapse(input, output, 1.0);
+    net.add_synapse(input, output, 1.0).unwrap();
 
     net.propagate(input, 2.0);
     assert!(approx_eq(net.value(output).unwrap(), 2.0));

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -6,7 +6,7 @@ fn network_json_roundtrip() {
     let mut net = Network::new();
     let inp = net.add_input_neuron("in", Activation::Identity);
     let out = net.add_output_neuron("out", Activation::Identity);
-    net.add_synapse(inp, out, 1.5);
+    net.add_synapse(inp, out, 1.5).unwrap();
 
     let mut path = std::env::temp_dir();
     path.push("net.json");

--- a/tests/xor_training.rs
+++ b/tests/xor_training.rs
@@ -25,12 +25,12 @@ fn xor_training_reduces_loss() {
     let h2 = net.add_neuron_with_activation(Activation::Sigmoid);
     let o = net.add_neuron_with_activation(Activation::Sigmoid);
 
-    net.add_synapse(i1, h1, 0.5);
-    net.add_synapse(i1, h2, -0.5);
-    net.add_synapse(i2, h1, -0.5);
-    net.add_synapse(i2, h2, 0.5);
-    net.add_synapse(h1, o, 0.5);
-    net.add_synapse(h2, o, 0.5);
+    net.add_synapse(i1, h1, 0.5).unwrap();
+    net.add_synapse(i1, h2, -0.5).unwrap();
+    net.add_synapse(i2, h1, -0.5).unwrap();
+    net.add_synapse(i2, h2, 0.5).unwrap();
+    net.add_synapse(h1, o, 0.5).unwrap();
+    net.add_synapse(h2, o, 0.5).unwrap();
 
     let dataset = [
         (vec![0.0, 0.0], vec![0.0]),


### PR DESCRIPTION
## Summary
- introduce `NetworkError::UnknownNeuron`
- change `add_synapse` and `add_synapse_with_id` to return `Result`
- update examples, docs, and tests to handle `NetworkError`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689316c6c7cc832190f8a88f4a3dc34d