### PR TITLE
Add cycle detection error to network graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ net.add_synapse(a, out, 1.0).unwrap();
 net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
-net.propagate_inputs();
+net.propagate_inputs().unwrap();
 let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
@@ -134,9 +134,9 @@ let dataset = [
     (vec![1.0, 1.0], vec![0.0]),
 ];
 
-net.train(&dataset, 10_000, 0.5);
+net.train(&dataset, 10_000, 0.5).unwrap();
 
-let output = net.predict(&[0.0, 1.0])[0];
+let output = net.predict(&[0.0, 1.0]).unwrap()[0];
 println!("XOR(0,1) ≈ {output}");
 ```
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -65,7 +65,7 @@ net.add_synapse(a, out, 1.0).unwrap();
 net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
-net.propagate_inputs();
+net.propagate_inputs().unwrap();
 let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
@@ -134,9 +134,9 @@ let dataset = [
     (vec![1.0, 1.0], vec![0.0]),
 ];
 
-net.train(&dataset, 10_000, 0.5);
+net.train(&dataset, 10_000, 0.5).unwrap();
 
-let output = net.predict(&[0.0, 1.0])[0];
+let output = net.predict(&[0.0, 1.0]).unwrap()[0];
 println!("XOR(0,1) ≈ {output}");
 ```
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -65,7 +65,7 @@ net.add_synapse(a, out, 1.0).unwrap();
 net.add_synapse(b, out, 1.0).unwrap();
 
 net.set_inputs(&[("a", 1.0), ("b", 0.0)]);
-net.propagate_inputs();
+net.propagate_inputs().unwrap();
 let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
@@ -134,9 +134,9 @@ let dataset = [
     (vec![1.0, 1.0], vec![0.0]),
 ];
 
-net.train(&dataset, 10_000, 0.5);
+net.train(&dataset, 10_000, 0.5).unwrap();
 
-let output = net.predict(&[0.0, 1.0])[0];
+let output = net.predict(&[0.0, 1.0]).unwrap()[0];
 println!("XOR(0,1) ≈ {output}");
 ```
 

--- a/examples/xor.rs
+++ b/examples/xor.rs
@@ -22,10 +22,10 @@ fn main() {
         (vec![1.0, 1.0], vec![0.0]),
     ];
 
-    net.train(&dataset, 10000, 0.5);
+    net.train(&dataset, 10000, 0.5).unwrap();
 
     for (inputs, _) in dataset.iter() {
-        let out = net.predict(inputs);
+        let out = net.predict(inputs).unwrap();
         println!("{:?} -> {:.3}", inputs, out[0]);
     }
 }

--- a/tests/io_api.rs
+++ b/tests/io_api.rs
@@ -14,7 +14,7 @@ fn test_named_inputs_outputs() {
     net.add_synapse(b, out, 1.0).unwrap();
 
     net.set_inputs(&[("a", 1.0), ("b", 2.0)]);
-    net.propagate_inputs();
+    net.propagate_inputs().unwrap();
     let outputs = net.get_outputs();
     assert!(approx_eq(outputs["sum"], 3.0));
 }
@@ -29,7 +29,7 @@ fn test_indexed_inputs_outputs() {
     net.add_synapse(b, out, 1.0).unwrap();
 
     net.set_inputs_by_index(&[1.0, 2.0]);
-    net.propagate_inputs();
+    net.propagate_inputs().unwrap();
     let outputs = net.get_outputs_by_index();
     assert!(approx_eq(outputs[0], 3.0));
 }

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -67,6 +67,19 @@ fn test_orphan_synapse() {
     assert!(matches!(res, Err(NetworkError::UnknownNeuron)));
 }
 
+/// Detect cycles in the network structure.
+#[test]
+fn test_cycle_detection() {
+    let mut net = Network::new();
+    let a = net.add_neuron();
+    let b = net.add_neuron();
+    net.add_synapse(a, b, 1.0).unwrap();
+    net.add_synapse(b, a, 1.0).unwrap();
+
+    let res = net.predict(&[]);
+    assert!(matches!(res, Err(NetworkError::CycleDetected)));
+}
+
 /// Neuron identifiers remain stable through string serialization.
 #[test]
 fn test_uuid_round_trip() {

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -16,7 +16,7 @@ fn network_json_roundtrip() {
     fs::remove_file(&path).ok();
 
     loaded.set_inputs(&[("in", 2.0)]);
-    loaded.propagate_inputs();
+    loaded.propagate_inputs().unwrap();
     let outputs = loaded.get_outputs();
     assert_eq!(outputs.get("out").copied().unwrap(), 3.0);
 }

--- a/tests/xor_training.rs
+++ b/tests/xor_training.rs
@@ -3,7 +3,7 @@ use aei_framework::{Activation, Network};
 fn loss(net: &mut Network, data: &[(Vec<f64>, Vec<f64>)]) -> f64 {
     data.iter()
         .map(|(inp, out)| {
-            let pred = net.predict(inp);
+            let pred = net.predict(inp).unwrap();
             pred.iter()
                 .zip(out.iter())
                 .map(|(a, b)| {
@@ -40,7 +40,7 @@ fn xor_training_reduces_loss() {
     ];
 
     let initial_loss = loss(&mut net, &dataset);
-    net.train(&dataset, 10000, 0.5);
+    net.train(&dataset, 10000, 0.5).unwrap();
     let final_loss = loss(&mut net, &dataset);
 
     assert!(final_loss < initial_loss);


### PR DESCRIPTION
## Summary
- add `NetworkError::CycleDetected`
- return `Result` from `graph_structure` and propagate errors through `propagate_inputs`, `predict` and `train`
- add regression test ensuring cycles are detected

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689319ec0f2c83219b3f12c1b54284a0