### PR TITLE
Use log crate for training progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Named input/output neurons with high-level `set_inputs`, `get_outputs`, and
   `propagate_inputs` APIs
 - JSON serialization and loading for networks via `save_json` and `load_json`
+- Structured logging of training progress via the `log` crate.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ resolver = "2"
 uuid = { version = "1.8", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+log = "0.4"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ ordered steps:
 This sequence guarantees that each neuron is activated exactly once per
 propagation and that previous runs do not leak into the next one.
 
+## Logging
+
+The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:
+
+```rust
+env_logger::init();
+```
+
+With a logger configured, progress from functions like `Network::train` will be reported at the `info` level.
+
 ## Project Structure
 
 ```

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Named input/output neurons with high-level `set_inputs`, `get_outputs`, and
   `propagate_inputs` APIs
 - JSON serialization and loading for networks via `save_json` and `load_json`
+- Structured logging of training progress via the `log` crate.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -211,6 +211,16 @@ ordered steps:
 This sequence guarantees that each neuron is activated exactly once per
 propagation and that previous runs do not leak into the next one.
 
+## Logging
+
+The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:
+
+```rust
+env_logger::init();
+```
+
+With a logger configured, progress from functions like `Network::train` will be reported at the `info` level.
+
 ## Project Structure
 
 ```

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -20,6 +20,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Tests couvrant toutes les fonctions d'activation et la propagation chaînée
 - Neurones d'entrée/sortie nommés avec les API de haut niveau `set_inputs`, `get_outputs` et `propagate_inputs`
 - Sérialisation et chargement JSON des réseaux via `save_json` et `load_json`
+- Journalisation structurée de la progression de l'entraînement via la crate `log`.
 ### Modifié
 - La logique de propagation applique désormais les activations après les sommes pondérées et réinitialise toutes les valeurs des neurones entre les exécutions.
 - Rustdoc complet pour les modules et les API publiques.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -211,6 +211,16 @@ sa fonction d'activation pour produire la nouvelle sortie.
 Cette séquence garantit que chaque neurone est activé exactement une fois par
 La propagation et que les courses précédentes ne fuient pas dans la suivante.
 
+## Journalisation
+
+Le framework émet des messages d'information via la crate [`log`](https://docs.rs/log). Pour afficher ces journaux, initialisez une implémentation de logger comme [`env_logger`](https://docs.rs/env_logger) dans votre application :
+
+```rust
+env_logger::init();
+```
+
+Avec un logger configuré, la progression de fonctions comme `Network::train` sera rapportée au niveau `info`.
+
 ## Structure du projet
 
 ```

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -477,7 +477,7 @@ impl Network {
             }
 
             let avg_loss = epoch_loss / dataset.len() as f64;
-            println!("Epoch {}/{} - loss: {}", epoch + 1, epochs, avg_loss);
+            log::info!("Epoch {}/{} - loss: {}", epoch + 1, epochs, avg_loss);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- integrate `log` crate into the workspace
- switch training progress output to `log::info!`
- document how to enable logging
- update README and CHANGELOG translations for logging

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68931cfadd6483218ed4d3f2fbf1e00c