### PR TITLE
feat: add random neuron mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `propagate_inputs` APIs
 - JSON serialization and loading for networks via `save_json` and `load_json`
 - Structured logging of training progress via the `log` crate.
+- Random neuron creation with `Network::add_random_neuron` generating automatic
+  connections.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ uuid = { version = "1.8", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
+rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Random Neuron Addition
+
+Grow the network by inserting a neuron with a random activation and automatic
+connections:
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+let new_neuron_id = net.add_random_neuron();
+println!("Added neuron: {new_neuron_id}");
+```
+
 ## Serialization
 
 Persist networks to disk and load them back later using JSON:

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `propagate_inputs` APIs
 - JSON serialization and loading for networks via `save_json` and `load_json`
 - Structured logging of training progress via the `log` crate.
+- Random neuron creation with `Network::add_random_neuron` generating automatic
+  connections.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -70,6 +70,19 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Random Neuron Addition
+
+Grow the network by inserting a neuron with a random activation and automatic
+connections:
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+let new_neuron_id = net.add_random_neuron();
+println!("Added neuron: {new_neuron_id}");
+```
+
 ## Serialization
 
 Persist networks to disk and load them back later using JSON:

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -21,6 +21,8 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Neurones d'entrée/sortie nommés avec les API de haut niveau `set_inputs`, `get_outputs` et `propagate_inputs`
 - Sérialisation et chargement JSON des réseaux via `save_json` et `load_json`
 - Journalisation structurée de la progression de l'entraînement via la crate `log`.
+- Création aléatoire de neurones avec `Network::add_random_neuron` générant des
+  connexions automatiques.
 ### Modifié
 - La logique de propagation applique désormais les activations après les sommes pondérées et réinitialise toutes les valeurs des neurones entre les exécutions.
 - Rustdoc complet pour les modules et les API publiques.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -70,6 +70,19 @@ let result = net.get_outputs();
 println!("Result: {:?}", result.get("out"));
 ```
 
+## Ajout aléatoire de neurone
+
+Étendez le réseau en insérant un neurone avec une activation et des connexions
+automatiques aléatoires :
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+let new_neuron_id = net.add_random_neuron();
+println!("Neurone ajouté : {new_neuron_id}");
+```
+
 ## Sérialisation
 
 Persistez les réseaux sur disque et rechargez-les ensuite en JSON :

--- a/tests/add_random_neuron.rs
+++ b/tests/add_random_neuron.rs
@@ -1,0 +1,29 @@
+use aei_framework::{Activation, Network};
+
+#[test]
+fn add_random_neuron_creates_connection() {
+    let mut net = Network::new();
+    let existing = net.add_neuron_with_activation(Activation::ReLU);
+    let new_id = net.add_random_neuron();
+
+    assert_ne!(new_id, existing);
+    assert!(!net.input_neurons.values().any(|&id| id == new_id));
+    assert!(!net.output_neurons.values().any(|&id| id == new_id));
+
+    let value = serde_json::to_value(&net).unwrap();
+    let neurons = value["neurons"].as_array().unwrap();
+    let n_json = neurons
+        .iter()
+        .find(|n| n["id"] == new_id.to_string())
+        .expect("new neuron missing");
+    let activation = n_json["activation"].as_str().unwrap();
+    assert!(["Identity", "Sigmoid", "ReLU", "Tanh"].contains(&activation));
+
+    let synapses = value["synapses"].as_array().unwrap();
+    let syn = synapses
+        .iter()
+        .find(|s| s["from"] == new_id.to_string() || s["to"] == new_id.to_string())
+        .expect("no synapse for new neuron");
+    let weight = syn["weight"].as_f64().unwrap();
+    assert!(weight >= -1.0 && weight <= 1.0);
+}

--- a/tests/add_random_neuron.rs
+++ b/tests/add_random_neuron.rs
@@ -25,5 +25,5 @@ fn add_random_neuron_creates_connection() {
         .find(|s| s["from"] == new_id.to_string() || s["to"] == new_id.to_string())
         .expect("no synapse for new neuron");
     let weight = syn["weight"].as_f64().unwrap();
-    assert!(weight >= -1.0 && weight <= 1.0);
+    assert!((-1.0..=1.0).contains(&weight));
 }


### PR DESCRIPTION
## Summary
- add `Network::add_random_neuron` for random activation and connections
- document random neuron addition in English and French READMEs
- cover random neuron creation with tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689322079ea48321afc9a30bc6847ead