### PR TITLE
feat: support random neuron removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured logging of training progress via the `log` crate.
 - Random neuron creation with `Network::add_random_neuron` generating automatic
   connections.
+- Random neuron removal with `Network::remove_random_neuron` deleting an internal neuron and its synapses.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ let new_neuron_id = net.add_random_neuron();
 println!("Added neuron: {new_neuron_id}");
 ```
 
+## Random Neuron Removal
+
+Shrink the network by deleting a random internal neuron along with all its
+connections:
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+// ... initialize the network ...
+if let Some(removed_id) = net.remove_random_neuron() {
+    println!("Removed neuron: {removed_id}");
+}
+```
+
 ## Serialization
 
 Persist networks to disk and load them back later using JSON:
@@ -275,4 +290,4 @@ Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for mor
 - Neuron and synapse identifiers use `Uuid`. Networks serialized with older
   numeric identifiers are not supported.
 - JSON persistence is available via `save_json` and `load_json`.
-- Layered abstractions and neuron removal are planned but not implemented.
+- Layered abstractions are planned but not implemented.

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured logging of training progress via the `log` crate.
 - Random neuron creation with `Network::add_random_neuron` generating automatic
   connections.
+- Random neuron removal with `Network::remove_random_neuron` deleting an internal neuron and its synapses.
 ### Changed
 - Propagation logic now applies activations after weighted sums and resets all
   neuron values between runs.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -83,6 +83,21 @@ let new_neuron_id = net.add_random_neuron();
 println!("Added neuron: {new_neuron_id}");
 ```
 
+## Random Neuron Removal
+
+Shrink the network by deleting a random internal neuron along with all its
+connections:
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+// ... initialize the network ...
+if let Some(removed_id) = net.remove_random_neuron() {
+    println!("Removed neuron: {removed_id}");
+}
+```
+
 ## Serialization
 
 Persist networks to disk and load them back later using JSON:
@@ -275,4 +290,4 @@ Distributed under the Mozilla Public License 2.0. See [LICENSE](LICENSE) for mor
 - Neuron and synapse identifiers use `Uuid`. Networks serialized with older
   numeric identifiers are not supported.
 - JSON persistence is available via `save_json` and `load_json`.
-- Layered abstractions and neuron removal are planned but not implemented.
+- Layered abstractions are planned but not implemented.

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -23,6 +23,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Journalisation structurée de la progression de l'entraînement via la crate `log`.
 - Création aléatoire de neurones avec `Network::add_random_neuron` générant des
   connexions automatiques.
+- Suppression aléatoire de neurone avec `Network::remove_random_neuron` supprimant un neurone interne et ses synapses.
 ### Modifié
 - La logique de propagation applique désormais les activations après les sommes pondérées et réinitialise toutes les valeurs des neurones entre les exécutions.
 - Rustdoc complet pour les modules et les API publiques.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -83,6 +83,20 @@ let new_neuron_id = net.add_random_neuron();
 println!("Neurone ajouté : {new_neuron_id}");
 ```
 
+## Suppression aléatoire de neurone
+
+Réduisez le réseau en supprimant un neurone interne aléatoire ainsi que toutes ses connexions :
+
+```rust
+use aei_framework::Network;
+
+let mut net = Network::new();
+// ... initialiser le réseau ...
+if let Some(removed_id) = net.remove_random_neuron() {
+    println!("Neurone supprimé : {removed_id}");
+}
+```
+
 ## Sérialisation
 
 Persistez les réseaux sur disque et rechargez-les ensuite en JSON :
@@ -274,4 +288,4 @@ Distribué sous la licence publique de Mozilla 2.0.
 
 - Les identificateurs de neurones et de synapses utilisent `Uuid`. Les réseaux sérialisés avec d'anciens identifiants numériques ne sont pas pris en charge.
 - La persistance JSON est disponible via `save_json` et `load_json`.
-- Les abstractions en couches et l'élimination des neurones sont planifiées mais non mises en œuvre.
+- Les abstractions en couches sont planifiées mais non mises en œuvre.

--- a/tests/remove_random_neuron.rs
+++ b/tests/remove_random_neuron.rs
@@ -1,0 +1,35 @@
+use aei_framework::{Activation, Network};
+
+#[test]
+fn remove_random_neuron_deletes_internal_and_synapses() {
+    let mut net = Network::new();
+    let input = net.add_input_neuron("in", Activation::Identity);
+    let hidden = net.add_neuron();
+    let output = net.add_output_neuron("out", Activation::Identity);
+    net.add_synapse(input, hidden, 1.0).unwrap();
+    net.add_synapse(hidden, output, 1.0).unwrap();
+
+    let removed = net.remove_random_neuron().expect("should remove");
+    assert_eq!(removed, hidden);
+
+    let value = serde_json::to_value(&net).unwrap();
+    let neurons = value["neurons"].as_array().unwrap();
+    assert!(neurons.iter().all(|n| n["id"] != removed.to_string()));
+    assert!(neurons.iter().any(|n| n["id"] == input.to_string()));
+    assert!(neurons.iter().any(|n| n["id"] == output.to_string()));
+
+    let synapses = value["synapses"].as_array().unwrap();
+    assert!(synapses
+        .iter()
+        .all(|s| s["from"] != removed.to_string() && s["to"] != removed.to_string()));
+}
+
+#[test]
+fn remove_random_neuron_returns_none_when_unavailable() {
+    let mut net = Network::new();
+    let a = net.add_input_neuron("a", Activation::Identity);
+    let b = net.add_output_neuron("b", Activation::Identity);
+    net.add_synapse(a, b, 1.0).unwrap();
+
+    assert!(net.remove_random_neuron().is_none());
+}


### PR DESCRIPTION
## Summary
- add `Network::remove_random_neuron` to drop a random internal neuron and its synapses
- document random neuron removal in the README and changelogs
- test removal behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893264826fc8321b09a21d2f5bb5bd1