### PR TITLE
feat: add DDD event-sourced architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,28 @@ With a logger configured, progress from functions like `Network::train` will be 
 src/
   core/        # activation, neuron, synapse primitives
   api/         # network implementation and public API
+  domain/      # event-sourced aggregates
+  events/      # domain events
+  commands.rs  # write-side commands
+  queries.rs   # read-side queries
+  application/ # command and query handlers
+  infrastructure/ # adapters such as the event store
 examples/
 tests/
 docs/
   en/
   fr/
 ```
+
+## Architecture Overview
+
+AEIF follows Domain-Driven Design with Event Sourcing and CQRS. State-changing
+operations are expressed as **commands** which are turned into immutable
+**events** and appended to an event log. Aggregates such as the `domain::Network`
+replay these events to rebuild their state. Read operations are served through
+separate **queries** handled by lightweight projections. This separation keeps
+the write path append-only and enables full traceability of the network's
+evolution.
 
 ## Documentation
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture
+
+This document describes the high-level design of the Autonomous & Evolutive
+Intelligence Framework.
+
+## Domain-Driven Design
+
+The framework models neurons, synapses and networks as domain entities. The
+`Network` aggregate applies events to maintain consistency across its internal
+state.
+
+## Event Sourcing
+
+Every state change is captured as an immutable event stored in an append-only
+log. Replaying the log reconstructs the exact state of the network, providing
+traceability and reproducibility.
+
+## CQRS
+
+Commands modify the system and queries read from it. Command handlers persist
+new events and update the aggregate, while query handlers serve read requests
+from the in-memory projection.
+
+## Extensibility
+
+Adapters for persistence or transport live under `infrastructure` and can be
+replaced to target different backends such as databases or message queues.

--- a/docs/fr/ARCHITECTURE.md
+++ b/docs/fr/ARCHITECTURE.md
@@ -1,0 +1,29 @@
+# Architecture
+
+Ce document décrit la conception de haut niveau du cadre Autonomous & Evolutive
+Intelligence Framework.
+
+## Domain-Driven Design
+
+Le framework modélise les neurones, synapses et réseaux comme entités métiers.
+L'agrégat `Network` applique les événements pour maintenir la cohérence de son
+état interne.
+
+## Event Sourcing
+
+Chaque modification d'état est capturée comme un événement immuable stocké dans
+un journal append-only. La relecture du journal reconstruit exactement l'état du
+réseau, assurant traçabilité et reproductibilité.
+
+## CQRS
+
+Les commandes modifient le système et les requêtes le consultent. Les handlers
+traitent les commandes en persistant de nouveaux événements et en mettant à jour
+l'agrégat, tandis que les query handlers répondent aux lectures à partir de la
+projection en mémoire.
+
+## Extensibilité
+
+Les adaptateurs de persistance ou de transport se trouvent dans
+`infrastructure` et peuvent être remplacés pour cibler différentes bases de
+données ou files de messages.

--- a/src/application/command_handler.rs
+++ b/src/application/command_handler.rs
@@ -1,0 +1,39 @@
+//! Handles write-side commands and persists resulting events.
+
+use crate::commands::Command;
+use crate::domain::Network;
+use crate::events::Event;
+use crate::infrastructure::EventStore;
+
+/// Processes commands, emitting events and updating the in-memory state.
+pub struct CommandHandler<S: EventStore> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state derived from applied events.
+    pub network: Network,
+}
+
+impl<S: EventStore> CommandHandler<S> {
+    /// Loads all events from the store and constructs a handler.
+    pub fn new(mut store: S) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self { store, network })
+    }
+
+    /// Handles a command by converting it to an event and applying it.
+    pub fn handle(&mut self, command: Command) -> Result<(), S::Error> {
+        let event = match command {
+            Command::AddNeuron { id, activation } => Event::NeuronAdded { id, activation },
+            Command::RemoveNeuron { id } => Event::NeuronRemoved { id },
+            Command::CreateSynapse { id, from, to, weight } => {
+                Event::SynapseCreated { id, from, to, weight }
+            }
+            Command::RemoveSynapse { id } => Event::SynapseRemoved { id },
+        };
+        self.store.append(&event)?;
+        self.network.apply(&event);
+        Ok(())
+    }
+}
+

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,0 +1,7 @@
+//! Application layer coordinating commands and queries.
+
+mod command_handler;
+mod query_handler;
+
+pub use command_handler::CommandHandler;
+pub use query_handler::{QueryHandler, QueryResult};

--- a/src/application/query_handler.rs
+++ b/src/application/query_handler.rs
@@ -1,0 +1,41 @@
+//! Handles read-side queries against the current state.
+
+use crate::domain::Network;
+use crate::queries::Query;
+use crate::core::Neuron;
+use uuid::Uuid;
+
+/// Result returned by the [`QueryHandler`].
+pub enum QueryResult<'a> {
+    /// Single neuron lookup.
+    Neuron(Option<&'a Neuron>),
+    /// Listing of all neurons.
+    Neurons(Vec<&'a Neuron>),
+}
+
+/// Provides read-only access to the network state.
+pub struct QueryHandler<'a> {
+    network: &'a Network,
+}
+
+impl<'a> QueryHandler<'a> {
+    /// Creates a new query handler from the given network reference.
+    pub fn new(network: &'a Network) -> Self {
+        Self { network }
+    }
+
+    /// Executes a query and returns a projection of the state.
+    pub fn handle(&self, query: Query) -> QueryResult<'a> {
+        match query {
+            Query::GetNeuron { id } => QueryResult::Neuron(self.network.neurons.get(&id)),
+            Query::ListNeurons => QueryResult::Neurons(self.network.neurons()),
+        }
+    }
+
+    /// Convenience method to fetch a neuron directly.
+    #[must_use]
+    pub fn neuron(&self, id: Uuid) -> Option<&'a Neuron> {
+        self.network.neurons.get(&id)
+    }
+}
+

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,23 @@
+//! Commands describing intent to change the domain state.
+
+use crate::core::Activation;
+use uuid::Uuid;
+
+/// Write-side operations handled by the [`CommandHandler`].
+#[derive(Debug, Clone)]
+pub enum Command {
+    /// Add a neuron with a specific activation function.
+    AddNeuron { id: Uuid, activation: Activation },
+    /// Remove a neuron and all attached synapses.
+    RemoveNeuron { id: Uuid },
+    /// Create a synapse between two existing neurons.
+    CreateSynapse {
+        id: Uuid,
+        from: Uuid,
+        to: Uuid,
+        weight: f64,
+    },
+    /// Delete a synapse by its identifier.
+    RemoveSynapse { id: Uuid },
+}
+

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,5 @@
+//! Domain aggregates modelling the state of the network.
+
+mod network;
+
+pub use network::Network;

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -1,0 +1,69 @@
+//! Event-sourced representation of a neural network.
+//!
+//! The [`Network`] aggregate stores neurons and synapses and evolves solely
+//! through the application of [`Event`]s.
+
+use std::collections::HashMap;
+
+use crate::core::{Neuron, Synapse};
+use crate::events::Event;
+use uuid::Uuid;
+
+/// Aggregate root containing all neurons and synapses.
+#[derive(Debug, Default, Clone)]
+pub struct Network {
+    /// Neurons indexed by their [`Uuid`].
+    pub neurons: HashMap<Uuid, Neuron>,
+    /// Synapses indexed by their [`Uuid`].
+    pub synapses: HashMap<Uuid, Synapse>,
+}
+
+impl Network {
+    /// Creates a network by replaying the provided events.
+    #[must_use]
+    pub fn hydrate(events: &[Event]) -> Self {
+        let mut net = Self::default();
+        for event in events {
+            net.apply(event);
+        }
+        net
+    }
+
+    /// Applies a domain event to mutate the aggregate state.
+    pub fn apply(&mut self, event: &Event) {
+        match event {
+            Event::NeuronAdded { id, activation } => {
+                self.neurons
+                    .insert(*id, Neuron::with_id(*id, *activation));
+            }
+            Event::NeuronRemoved { id } => {
+                self.neurons.remove(id);
+                self.synapses
+                    .retain(|_, s| s.from != *id && s.to != *id);
+            }
+            Event::SynapseCreated {
+                id,
+                from,
+                to,
+                weight,
+            } => {
+                if self.neurons.contains_key(from) && self.neurons.contains_key(to) {
+                    self.synapses.insert(
+                        *id,
+                        Synapse::with_id(*id, *from, *to, *weight),
+                    );
+                }
+            }
+            Event::SynapseRemoved { id } => {
+                self.synapses.remove(id);
+            }
+        }
+    }
+
+    /// Convenience method to list all neurons.
+    #[must_use]
+    pub fn neurons(&self) -> Vec<&Neuron> {
+        self.neurons.values().collect()
+    }
+}
+

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,27 @@
+//! Domain events representing state changes in the network.
+//!
+//! Events are persisted in an append-only log and can be replayed to
+//! reconstruct the state of the system.
+
+use crate::core::Activation;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Business events emitted by command handlers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Event {
+    /// A neuron was added to the network.
+    NeuronAdded { id: Uuid, activation: Activation },
+    /// A neuron was removed from the network.
+    NeuronRemoved { id: Uuid },
+    /// A synapse connecting two neurons was created.
+    SynapseCreated {
+        id: Uuid,
+        from: Uuid,
+        to: Uuid,
+        weight: f64,
+    },
+    /// A synapse was removed from the network.
+    SynapseRemoved { id: Uuid },
+}
+

--- a/src/infrastructure/event_store.rs
+++ b/src/infrastructure/event_store.rs
@@ -1,0 +1,65 @@
+//! Append-only event storage.
+//!
+//! The default [`FileEventStore`] writes JSON encoded events to disk, one per
+//! line. The log can later be replayed to rebuild the full network state.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use crate::events::Event;
+
+/// Storage backend for domain events.
+pub trait EventStore {
+    /// The error type produced by this event store.
+    type Error;
+    /// Persist an event to the underlying storage.
+    fn append(&mut self, event: &Event) -> Result<(), Self::Error>;
+    /// Load all events in chronological order.
+    fn load(&mut self) -> Result<Vec<Event>, Self::Error>;
+}
+
+/// JSON-lines file based implementation of [`EventStore`].
+#[derive(Debug)]
+pub struct FileEventStore {
+    path: PathBuf,
+}
+
+impl FileEventStore {
+    /// Creates a new store writing to the specified path.
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl EventStore for FileEventStore {
+    type Error = io::Error;
+
+    fn append(&mut self, event: &Event) -> Result<(), Self::Error> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        let json = serde_json::to_string(event).map_err(io::Error::other)?;
+        writeln!(file, "{}", json)
+    }
+
+    fn load(&mut self) -> Result<Vec<Event>, Self::Error> {
+        let mut events = Vec::new();
+        if !self.path.exists() {
+            return Ok(events);
+        }
+        let file = File::open(&self.path)?;
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let event: Event = serde_json::from_str(&line).map_err(io::Error::other)?;
+            events.push(event);
+        }
+        Ok(events)
+    }
+}
+

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,0 +1,5 @@
+//! Infrastructure components such as persistence adapters.
+
+mod event_store;
+
+pub use event_store::{EventStore, FileEventStore};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,19 @@
 //! modular neural networks.
 
 pub mod api;
+pub mod application;
+pub mod commands;
 pub mod core;
+pub mod domain;
+pub mod events;
+pub mod infrastructure;
+pub mod queries;
 
 pub use api::{Network, NetworkError};
+pub use application::{CommandHandler, QueryHandler, QueryResult};
+pub use commands::Command;
 pub use core::{Activation, Neuron, Synapse};
+pub use domain::Network as DomainNetwork;
+pub use events::Event;
+pub use infrastructure::{EventStore, FileEventStore};
+pub use queries::Query;

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,0 +1,13 @@
+//! Read-side queries executed against projections of the domain state.
+
+use uuid::Uuid;
+
+/// Query operations handled by the [`QueryHandler`].
+#[derive(Debug, Clone)]
+pub enum Query {
+    /// Fetch a neuron by identifier.
+    GetNeuron { id: Uuid },
+    /// Return all known neurons.
+    ListNeurons,
+}
+

--- a/tests/event_sourcing.rs
+++ b/tests/event_sourcing.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    application::{CommandHandler, QueryHandler},
+    commands::Command,
+    core::Activation,
+    infrastructure::FileEventStore,
+    Query,
+    QueryResult,
+};
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_es_{}.log", Uuid::new_v4()));
+    path
+}
+
+#[test]
+fn add_and_replay_neuron() {
+    let path = temp_path();
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+    let id = Uuid::new_v4();
+    handler
+        .handle(Command::AddNeuron {
+            id,
+            activation: Activation::Identity,
+        })
+        .unwrap();
+
+    let query = QueryHandler::new(&handler.network);
+    match query.handle(Query::GetNeuron { id }) {
+        QueryResult::Neuron(Some(n)) => assert_eq!(n.id, id),
+        _ => panic!("neuron not found"),
+    }
+
+    // Reload from the same event store and ensure the neuron persists.
+    let store = FileEventStore::new(path);
+    let handler = CommandHandler::new(store).unwrap();
+    assert!(handler.network.neurons.get(&id).is_some());
+}
+
+#[test]
+fn create_and_remove_synapse() {
+    let path = temp_path();
+    let store = FileEventStore::new(path);
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    handler
+        .handle(Command::AddNeuron {
+            id: n1,
+            activation: Activation::ReLU,
+        })
+        .unwrap();
+    handler
+        .handle(Command::AddNeuron {
+            id: n2,
+            activation: Activation::Tanh,
+        })
+        .unwrap();
+
+    let syn_id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateSynapse {
+            id: syn_id,
+            from: n1,
+            to: n2,
+            weight: 1.0,
+        })
+        .unwrap();
+    assert!(handler.network.synapses.get(&syn_id).is_some());
+
+    handler
+        .handle(Command::RemoveSynapse { id: syn_id })
+        .unwrap();
+    assert!(handler.network.synapses.get(&syn_id).is_none());
+}
+


### PR DESCRIPTION
## Summary
- model domain events and event-sourced network aggregate
- add command/query handling with file-based event store
- document architecture and provide event sourcing tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68935604b5bc83218f53cb8ee0b4ff66