### PR TITLE
chore: remove unused aliases and modules crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Neuron and synapse identifiers now use `Uuid` instead of numeric indexes.
 - Project structure now separates `core` primitives and `api` network module.
 - Documentation mirrored in English and French under `docs/`.
+### Removed
+- Unused `NodeList` and `TopoOrder` type aliases in the network API.
+- Empty `modules` crate from the workspace.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = [
     "crates/core",
     "crates/memory",
     "crates/runtime",
-    "crates/modules",
     "crates/utils",
 ]
 resolver = "2"

--- a/crates/modules/Cargo.toml
+++ b/crates/modules/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "aei-modules"
-version = "0.1.0"
-edition = "2021"
-description = "Plug-and-play knowledge modules for ACUs."
-license = "MPL-2.0"
-
-[dependencies]

--- a/crates/modules/src/lib.rs
+++ b/crates/modules/src/lib.rs
@@ -1,2 +1,0 @@
-//! Collection of plug-and-play knowledge modules used to extend
-//! the capabilities of Autonomous Conscious Units (ACUs).

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -32,3 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Neuron and synapse identifiers now use `Uuid` instead of numeric indexes.
 - Project structure now separates `core` primitives and `api` network module.
 - Documentation mirrored in English and French under `docs/`.
+### Removed
+- Unused `NodeList` and `TopoOrder` type aliases in the network API.
+- Empty `modules` crate from the workspace.

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -30,3 +30,6 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Les identifiants des neurones et des synapses utilisent désormais `Uuid` au lieu d'index numériques.
 - La structure du projet sépare désormais les primitives `core` et le module réseau `api`.
 - La documentation est disponible en anglais et en français sous `docs/`.
+### Supprimé
+- Alias de type inutilisés `NodeList` et `TopoOrder` dans l'API réseau.
+- Crate `modules` vide retirée de l'espace de travail.

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -1,9 +1,7 @@
 //! Dynamic neural network composed of neurons and synapses.
 
 type EdgeList = Vec<Vec<(usize, usize)>>;
-type NodeList = Vec<usize>;
-type TopoOrder = Vec<usize>;
-type GraphStructure = (EdgeList, EdgeList, NodeList, NodeList, TopoOrder);
+type GraphStructure = (EdgeList, EdgeList, Vec<usize>, Vec<usize>, Vec<usize>);
 
 use std::collections::{HashMap, VecDeque};
 use std::fs::File;


### PR DESCRIPTION
## Summary
- remove NodeList/TopoOrder aliases from network API
- drop empty modules crate from workspace
- update changelogs in English and French

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893607fae8c83219cf14c0edf6d3d3b