### PR TITLE
Add random synapse removal with event sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AddRandomNeuronHandler`.
 - Event-sourced random neuron removal via `RemoveRandomNeuronCommand` and
   `RemoveRandomNeuronHandler`.
+- Event-sourced random synapse removal via `RemoveRandomSynapseCommand` and
+  `RemoveRandomSynapseHandler`.
 ### Changed
 - Commands and queries now reside in the `application` module.
 - Domain events moved under `domain` and exposed via `domain::events`.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,10 @@
+# Glossary
+
+## Random Synapse Removal
+Process of deleting a randomly selected synapse via `RemoveRandomSynapseCommand` and the ensuing `RandomSynapseRemoved` event.
+
+## RemoveRandomSynapseCommand
+Command requesting the removal of a random synapse from the network.
+
+## RandomSynapseRemoved
+Domain event indicating that a synapse chosen at random was removed from the network.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ let synapse_id = handler.handle(AddRandomSynapseCommand).unwrap();
 println!("Created synapse: {synapse_id}");
 ```
 
+## Random Synapse Removal
+
+Delete a randomly selected synapse and record the action as an event:
+
+```rust
+use aei_framework::{
+    RemoveRandomSynapseCommand, RemoveRandomSynapseHandler, FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = RemoveRandomSynapseHandler::new(store, thread_rng()).unwrap();
+if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
+    println!("Removed synapse: {removed_id}");
+}
+```
+
 ## Logging
 
 The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AddRandomNeuronHandler`.
 - Event-sourced random neuron removal via `RemoveRandomNeuronCommand` and
   `RemoveRandomNeuronHandler`.
+- Event-sourced random synapse removal via `RemoveRandomSynapseCommand` and
+  `RemoveRandomSynapseHandler`.
 ### Changed
 - Commands and queries now reside in the `application` module.
 - Domain events moved under `domain` and exposed via `domain::events`.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -65,6 +65,24 @@ let synapse_id = handler.handle(AddRandomSynapseCommand).unwrap();
 println!("Created synapse: {synapse_id}");
 ```
 
+## Random Synapse Removal
+
+Remove a random synapse through an event-driven handler:
+
+```rust
+use aei_framework::{
+    RemoveRandomSynapseCommand, RemoveRandomSynapseHandler, FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = RemoveRandomSynapseHandler::new(store, thread_rng()).unwrap();
+if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
+    println!("Removed synapse: {removed_id}");
+}
+```
+
 ## Logging
 
 The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -27,6 +27,8 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `AddRandomNeuronHandler`.
 - Suppression aléatoire de neurone orientée événements via `RemoveRandomNeuronCommand` et
   `RemoveRandomNeuronHandler`.
+- Suppression aléatoire de synapse orientée événements via `RemoveRandomSynapseCommand` et
+  `RemoveRandomSynapseHandler`.
 ### Modifié
 - Les commandes et requêtes résident désormais dans le module `application`.
 - Les événements de domaine ont été déplacés sous `domain` et exposés via `domain::events`.

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -1,0 +1,10 @@
+# Glossaire
+
+## Suppression aléatoire de synapse
+Processus de suppression d'une synapse sélectionnée aléatoirement via `RemoveRandomSynapseCommand` et l'événement `RandomSynapseRemoved`.
+
+## RemoveRandomSynapseCommand
+Commande demandant la suppression d'une synapse aléatoire du réseau.
+
+## RandomSynapseRemoved
+Événement de domaine indiquant qu'une synapse choisie aléatoirement a été supprimée du réseau.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -63,6 +63,24 @@ let synapse_id = handler.handle(AddRandomSynapseCommand).unwrap();
 println!("Synapse créée : {synapse_id}");
 ```
 
+## Suppression aléatoire de synapse
+
+Supprimez une synapse sélectionnée aléatoirement via un gestionnaire orienté événements :
+
+```rust
+use aei_framework::{
+    RemoveRandomSynapseCommand, RemoveRandomSynapseHandler, FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = RemoveRandomSynapseHandler::new(store, thread_rng()).unwrap();
+if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
+    println!("Synapse supprimée : {removed_id}");
+}
+```
+
 ## Journalisation
 
 Le framework émet des messages d'information via la crate [`log`](https://docs.rs/log). Pour afficher ces journaux, initialisez une implémentation de logger comme [`env_logger`](https://docs.rs/env_logger) dans votre application :

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -7,6 +7,7 @@ mod commands;
 mod queries;
 mod query_handler;
 mod remove_random_neuron;
+mod remove_random_synapse;
 
 pub use add_random_neuron::{AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler};
 pub use add_random_synapse::{
@@ -18,4 +19,7 @@ pub use queries::Query;
 pub use query_handler::{QueryHandler, QueryResult};
 pub use remove_random_neuron::{
     RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
+};
+pub use remove_random_synapse::{
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };

--- a/src/application/remove_random_synapse.rs
+++ b/src/application/remove_random_synapse.rs
@@ -1,0 +1,93 @@
+//! Command and handler for removing a random synapse.
+
+use rand::{seq::SliceRandom, Rng};
+use uuid::Uuid;
+
+use crate::domain::{Event, Network, RandomSynapseRemoved};
+use crate::infrastructure::EventStore;
+
+/// Command requesting the removal of a random synapse.
+///
+/// # Examples
+/// ```
+/// use aei_framework::RemoveRandomSynapseCommand;
+/// let cmd = RemoveRandomSynapseCommand;
+/// println!("{:?}", cmd);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RemoveRandomSynapseCommand;
+
+/// Errors that can occur when removing a synapse.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RemoveRandomSynapseError {
+    /// The network does not contain any synapse to remove.
+    NoSynapseAvailable,
+    /// Persisting the event failed.
+    StorageError,
+}
+
+/// Handles [`RemoveRandomSynapseCommand`], emitting events and updating state.
+pub struct RemoveRandomSynapseHandler<S: EventStore, R: Rng> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state derived from applied events.
+    pub network: Network,
+    rng: R,
+}
+
+impl<S: EventStore, R: Rng> RemoveRandomSynapseHandler<S, R> {
+    /// Loads events from the store to initialize the handler.
+    ///
+    /// # Errors
+    /// Propagates storage backend errors.
+    pub fn new(mut store: S, rng: R) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self {
+            store,
+            network,
+            rng,
+        })
+    }
+
+    /// Handles the command and returns the identifier of the removed synapse.
+    ///
+    /// # Errors
+    /// Returns [`RemoveRandomSynapseError::NoSynapseAvailable`] if the network
+    /// does not contain any synapse and
+    /// [`RemoveRandomSynapseError::StorageError`] if persisting the event
+    /// fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use aei_framework::{
+    ///     RemoveRandomSynapseCommand, RemoveRandomSynapseHandler, FileEventStore,
+    /// };
+    /// use rand::thread_rng;
+    /// use std::path::PathBuf;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = FileEventStore::new(PathBuf::from("events.log"));
+    /// let mut handler = RemoveRandomSynapseHandler::new(store, thread_rng())?;
+    /// let _ = handler.handle(RemoveRandomSynapseCommand);
+    /// # Ok(()) }
+    /// ```
+    pub fn handle(
+        &mut self,
+        _cmd: RemoveRandomSynapseCommand,
+    ) -> Result<Uuid, RemoveRandomSynapseError> {
+        let ids: Vec<Uuid> = self.network.synapses.keys().copied().collect();
+        if ids.is_empty() {
+            return Err(RemoveRandomSynapseError::NoSynapseAvailable);
+        }
+        let synapse_id = *ids
+            .choose(&mut self.rng)
+            .expect("candidate list is non-empty");
+        let event = Event::RandomSynapseRemoved(RandomSynapseRemoved { synapse_id });
+        self.store
+            .append(&event)
+            .map_err(|_| RemoveRandomSynapseError::StorageError)?;
+        self.network.apply(&event);
+        Ok(synapse_id)
+    }
+}

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -25,6 +25,8 @@ pub enum Event {
     SynapseRemoved { id: Uuid },
     /// A synapse between two randomly selected neurons was added.
     RandomSynapseAdded(RandomSynapseAdded),
+    /// A randomly chosen synapse was removed from the network.
+    RandomSynapseRemoved(RandomSynapseRemoved),
 }
 
 /// Event emitted when a random neuron is added to the network.
@@ -54,4 +56,11 @@ pub struct RandomSynapseAdded {
     pub to: Uuid,
     /// Weight associated with the synapse.
     pub weight: f64,
+}
+
+/// Event emitted when a random synapse is removed from the network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RandomSynapseRemoved {
+    /// Identifier of the removed synapse.
+    pub synapse_id: Uuid,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -7,7 +7,9 @@ mod neuron;
 mod synapse;
 
 pub use activation::Activation;
-pub use events::{Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded};
+pub use events::{
+    Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+};
 pub use network::Network;
 pub use neuron::Neuron;
 pub use synapse::Synapse;

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 
-use super::events::{Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded};
+use super::events::{
+    Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+};
 use super::{Neuron, Synapse};
 use uuid::Uuid;
 
@@ -55,6 +57,9 @@ impl Network {
             Event::RandomSynapseAdded(e) => {
                 self.apply_random_synapse_added(e);
             }
+            Event::RandomSynapseRemoved(e) => {
+                self.apply_random_synapse_removed(e);
+            }
         }
     }
 
@@ -88,6 +93,11 @@ impl Network {
                 Synapse::with_id(event.synapse_id, event.from, event.to, event.weight),
             );
         }
+    }
+
+    /// Applies a [`RandomSynapseRemoved`] event to the network state.
+    fn apply_random_synapse_removed(&mut self, event: &RandomSynapseRemoved) {
+        self.synapses.remove(&event.synapse_id);
     }
 
     /// Convenience method to list all neurons.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,10 @@ pub use application::{
     AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler, AddRandomSynapseCommand,
     AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler, Query, QueryHandler,
     QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };
 pub use domain::{
     Activation, Event, Network as DomainNetwork, Neuron, RandomNeuronAdded, RandomNeuronRemoved,
-    RandomSynapseAdded, Synapse,
+    RandomSynapseAdded, RandomSynapseRemoved, Synapse,
 };
 pub use infrastructure::{EventStore, FileEventStore};

--- a/tests/synapse_commands.rs
+++ b/tests/synapse_commands.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use aei_framework::{
     Activation, AddRandomSynapseCommand, AddRandomSynapseError, AddRandomSynapseHandler, Event,
-    EventStore, FileEventStore, RandomNeuronAdded, RandomSynapseAdded,
+    EventStore, FileEventStore, RandomNeuronAdded, RandomSynapseAdded, RandomSynapseRemoved,
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -28,6 +29,16 @@ fn seed_two_neurons(store: &mut FileEventStore, n1: Uuid, n2: Uuid) {
     for e in &events {
         store.append(e).unwrap();
     }
+}
+
+fn seed_synapse(store: &mut FileEventStore, id: Uuid, from: Uuid, to: Uuid) {
+    let event = Event::SynapseCreated {
+        id,
+        from,
+        to,
+        weight: 1.0,
+    };
+    store.append(&event).unwrap();
 }
 
 #[test]
@@ -87,4 +98,71 @@ fn add_random_synapse_errors_when_no_connection_available() {
         res,
         Err(AddRandomSynapseError::NoAvailableConnection)
     ));
+}
+
+#[test]
+fn remove_random_synapse_appends_event() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    seed_two_neurons(&mut store, n1, n2);
+    let syn = Uuid::new_v4();
+    seed_synapse(&mut store, syn, n1, n2);
+
+    let rng = ChaCha8Rng::seed_from_u64(4);
+    let mut handler = RemoveRandomSynapseHandler::new(store, rng).unwrap();
+    let removed_id = handler
+        .handle(RemoveRandomSynapseCommand)
+        .expect("synapse removed");
+    assert!(!handler.network.synapses.contains_key(&removed_id));
+
+    let mut store = handler.store;
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::RandomSynapseRemoved(RandomSynapseRemoved { synapse_id }) => {
+            assert_eq!(*synapse_id, removed_id)
+        }
+        e => panic!("unexpected event {e:?}"),
+    }
+}
+
+#[test]
+fn remove_random_synapse_errors_when_empty() {
+    let path = temp_path();
+    let store = FileEventStore::new(path);
+    let rng = ChaCha8Rng::seed_from_u64(5);
+    let mut handler = RemoveRandomSynapseHandler::new(store, rng).unwrap();
+    let res = handler.handle(RemoveRandomSynapseCommand);
+    assert!(matches!(
+        res,
+        Err(RemoveRandomSynapseError::NoSynapseAvailable)
+    ));
+}
+
+#[test]
+fn remove_random_synapse_event_replay() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    seed_two_neurons(&mut store, n1, n2);
+    let syn = Uuid::new_v4();
+    seed_synapse(&mut store, syn, n1, n2);
+
+    let rng = ChaCha8Rng::seed_from_u64(6);
+    let mut handler = RemoveRandomSynapseHandler::new(store, rng).unwrap();
+    let removed_id = handler
+        .handle(RemoveRandomSynapseCommand)
+        .expect("synapse removed");
+
+    let store = handler.store;
+    let mut replay_store = store;
+    let events = replay_store.load().unwrap();
+    let net = aei_framework::DomainNetwork::hydrate(&events);
+    assert!(!net.synapses.contains_key(&removed_id));
+
+    let projection =
+        aei_framework::infrastructure::projection::NetworkProjection::from_events(&events);
+    assert!(projection.synapses().is_empty());
 }


### PR DESCRIPTION
## Summary
- add `RandomSynapseRemoved` event and network application
- introduce `RemoveRandomSynapseCommand` with handler and docs
- cover removal with tests, README updates, and glossary entries

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68944f83f1bc8321b2276c8ac63568d5