### PR TITLE
feat: mutate synapse weight via domain event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`
 - Activation function derivatives enabling gradient descent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 rand = "0.8"
+rand_distr = "0.4"
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -55,3 +55,9 @@ Command that creates a synapse between two randomly chosen neurons. Implemented 
 
 ### RemoveRandomSynapseCommand
 Command requesting the removal of a random synapse from the network. Implemented in [src/application/add_random_synapse.rs](src/application/remove_random_synapse.rs).
+
+### MutateRandomSynapseWeightCommand
+Command that mutates the weight of a randomly selected synapse by adding Gaussian noise. Implemented in [src/application/mutate_random_synapse_weight.rs](src/application/mutate_random_synapse_weight.rs).
+
+### SynapseWeightMutated
+Domain event recording a change in a synapse's weight. Emitted by `MutateRandomSynapseWeightHandler`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
 }
 ```
 
+## Random Synapse Weight Mutation
+
+Adjust a synapse's weight by adding Gaussian noise:
+
+```rust
+use aei_framework::{
+    MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightHandler, FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = MutateRandomSynapseWeightHandler::new(store, thread_rng()).unwrap();
+if let Ok(synapse_id) =
+    handler.handle(MutateRandomSynapseWeightCommand { std_dev: 0.1 })
+{
+    println!("Mutated synapse: {synapse_id}");
+}
+```
+
 ## Logging
 
 The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:
@@ -128,6 +148,13 @@ replay these events to rebuild their state. Read operations are served through
 separate **queries** handled by projections located under
 `infrastructure/projection`. This separation keeps the write path append-only
 and enables full traceability of the network's evolution.
+
+**Command → Event → Apply → Projection**
+
+1. A command expresses intent to mutate state.
+2. The handler emits and persists a domain event.
+3. The aggregate applies the event to update its state.
+4. Projections consume the event to refresh read models.
 
 ## Documentation
 

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`
 - Activation function derivatives enabling gradient descent

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -7,6 +7,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Non publié]
 ### Ajouté
+- Mutation aléatoire du poids des synapses via `MutateRandomSynapseWeightCommand` et `MutateRandomSynapseWeightHandler`.
 - Exemple orienté événements et tests de commande de synapse.
 - Entraînement par rétropropagation avec `Network::train` et `Network::predict`
 - Dérivées des fonctions d'activation permettant la descente de gradient

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -55,3 +55,9 @@ Commande qui crée une synapse entre deux neurones choisis aléatoirement. Impl�
 
 ## RemoveRandomSynapseCommand
 Commande demandant la suppression d'une synapse aléatoire du réseau. Implémentée dans [src/application/add_random_synapse.rs](../../src/application/remove_random_synapse.rs).
+
+### MutateRandomSynapseWeightCommand
+Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoirement. Implémentée dans [src/application/mutate_random_synapse_weight.rs](../../src/application/mutate_random_synapse_weight.rs).
+
+### SynapseWeightMutated
+Événement de domaine enregistrant la modification du poids d'une synapse. Émis par `MutateRandomSynapseWeightHandler`.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -81,6 +81,26 @@ if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
 }
 ```
 
+## Mutation aléatoire du poids d'une synapse
+
+Ajustez le poids d'une synapse en ajoutant un bruit gaussien :
+
+```rust
+use aei_framework::{
+    MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightHandler, FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = MutateRandomSynapseWeightHandler::new(store, thread_rng()).unwrap();
+if let Ok(synapse_id) =
+    handler.handle(MutateRandomSynapseWeightCommand { std_dev: 0.1 })
+{
+    println!("Synapse mutée : {synapse_id}");
+}
+```
+
 ## Journalisation
 
 Le framework émet des messages d'information via la crate [`log`](https://docs.rs/log). Pour afficher ces journaux, initialisez une implémentation de logger comme [`env_logger`](https://docs.rs/env_logger) dans votre application :
@@ -120,6 +140,13 @@ docs/
 ## Aperçu de l'architecture
 
 AEIF suit le Domain-Driven Design avec Event Sourcing et CQRS. Les opérations modifiant l'état sont exprimées sous forme de **commandes** transformées en **événements** immuables et ajoutées à un journal. Les agrégats tels que `domain::Network` rejouent ces événements pour reconstruire leur état. Les lectures sont servies via des **requêtes** traitées par des projections situées sous `infrastructure/projection`.
+
+**Commande → Événement → Application → Projection**
+
+1. Une commande exprime l'intention de modifier l'état.
+2. Le gestionnaire émet et persiste un événement de domaine.
+3. L'agrégat applique l'événement pour mettre à jour son état.
+4. Les projections consomment l'événement pour rafraîchir les modèles de lecture.
 
 ## Documentation
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@ mod add_random_neuron;
 mod add_random_synapse;
 mod command_handler;
 mod commands;
+mod mutate_random_synapse_weight;
 mod queries;
 mod query_handler;
 mod remove_random_neuron;
@@ -15,6 +16,10 @@ pub use add_random_synapse::{
 };
 pub use command_handler::CommandHandler;
 pub use commands::Command;
+pub use mutate_random_synapse_weight::{
+    MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
+    MutateRandomSynapseWeightHandler,
+};
 pub use queries::Query;
 pub use query_handler::{QueryHandler, QueryResult};
 pub use remove_random_neuron::{

--- a/src/application/mutate_random_synapse_weight.rs
+++ b/src/application/mutate_random_synapse_weight.rs
@@ -1,0 +1,112 @@
+//! Command and handler for mutating the weight of a random synapse.
+//!
+//! The mutation adds Gaussian noise with a configurable standard deviation to
+//! the existing weight. A corresponding [`SynapseWeightMutated`] event is
+//! emitted, persisted, and applied to the domain.
+
+use rand::{seq::SliceRandom, Rng};
+use rand_distr::{Distribution, Normal};
+use uuid::Uuid;
+
+use crate::domain::{Event, Network, SynapseWeightMutated};
+use crate::infrastructure::EventStore;
+
+/// Command requesting mutation of a random synapse weight.
+#[derive(Debug, Clone, Copy)]
+pub struct MutateRandomSynapseWeightCommand {
+    /// Standard deviation of the Gaussian noise to add to the weight.
+    pub std_dev: f64,
+}
+
+/// Errors that can occur while mutating a synapse weight.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MutateRandomSynapseWeightError {
+    /// The network does not contain any synapse to mutate.
+    NoSynapseAvailable,
+    /// The provided standard deviation is not valid (must be positive).
+    InvalidStdDev,
+    /// Persisting the event failed.
+    StorageError,
+}
+
+/// Handles [`MutateRandomSynapseWeightCommand`], emitting and applying
+/// [`SynapseWeightMutated`] events.
+pub struct MutateRandomSynapseWeightHandler<S: EventStore, R: Rng> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state derived from applied events.
+    pub network: Network,
+    rng: R,
+}
+
+impl<S: EventStore, R: Rng> MutateRandomSynapseWeightHandler<S, R> {
+    /// Loads events from the store to initialize the handler.
+    pub fn new(mut store: S, rng: R) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self {
+            store,
+            network,
+            rng,
+        })
+    }
+
+    /// Handles the command and returns the identifier of the mutated synapse.
+    ///
+    /// # Errors
+    /// Returns [`MutateRandomSynapseWeightError::NoSynapseAvailable`] if the
+    /// network contains no synapse, [`MutateRandomSynapseWeightError::InvalidStdDev`]
+    /// if the provided standard deviation is non-positive, and
+    /// [`MutateRandomSynapseWeightError::StorageError`] if persisting the event
+    /// fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use aei_framework::{
+    ///     MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightHandler, FileEventStore,
+    /// };
+    /// use rand::thread_rng;
+    /// use std::path::PathBuf;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = FileEventStore::new(PathBuf::from("events.log"));
+    /// let mut handler = MutateRandomSynapseWeightHandler::new(store, thread_rng())?;
+    /// let _ = handler.handle(MutateRandomSynapseWeightCommand { std_dev: 0.1 });
+    /// # Ok(()) }
+    /// ```
+    pub fn handle(
+        &mut self,
+        cmd: MutateRandomSynapseWeightCommand,
+    ) -> Result<Uuid, MutateRandomSynapseWeightError> {
+        if cmd.std_dev <= 0.0 {
+            return Err(MutateRandomSynapseWeightError::InvalidStdDev);
+        }
+        let ids: Vec<Uuid> = self.network.synapses.keys().copied().collect();
+        if ids.is_empty() {
+            return Err(MutateRandomSynapseWeightError::NoSynapseAvailable);
+        }
+        let synapse_id = *ids
+            .choose(&mut self.rng)
+            .expect("candidate list is non-empty");
+        let old_weight = self
+            .network
+            .synapses
+            .get(&synapse_id)
+            .expect("synapse exists")
+            .weight;
+        let normal = Normal::new(0.0, cmd.std_dev)
+            .map_err(|_| MutateRandomSynapseWeightError::InvalidStdDev)?;
+        let noise = normal.sample(&mut self.rng);
+        let new_weight = old_weight + noise;
+        let event = Event::SynapseWeightMutated(SynapseWeightMutated {
+            synapse_id,
+            old_weight,
+            new_weight,
+        });
+        self.store
+            .append(&event)
+            .map_err(|_| MutateRandomSynapseWeightError::StorageError)?;
+        self.network.apply(&event);
+        Ok(synapse_id)
+    }
+}

--- a/src/application/queries.rs
+++ b/src/application/queries.rs
@@ -11,4 +11,6 @@ pub enum Query {
     ListNeurons,
     /// Return all known synapses.
     ListSynapses,
+    /// Fetch a synapse by identifier.
+    GetSynapse { id: Uuid },
 }

--- a/src/application/query_handler.rs
+++ b/src/application/query_handler.rs
@@ -13,6 +13,8 @@ pub enum QueryResult<'a> {
     Neurons(Vec<&'a Neuron>),
     /// Listing of all synapses.
     Synapses(Vec<&'a Synapse>),
+    /// Single synapse lookup.
+    Synapse(Option<&'a Synapse>),
 }
 
 /// Provides read-only access to the network state.
@@ -32,6 +34,7 @@ impl<'a> QueryHandler<'a> {
             Query::GetNeuron { id } => QueryResult::Neuron(self.projection.neuron(id)),
             Query::ListNeurons => QueryResult::Neurons(self.projection.neurons()),
             Query::ListSynapses => QueryResult::Synapses(self.projection.synapses()),
+            Query::GetSynapse { id } => QueryResult::Synapse(self.projection.synapse(id)),
         }
     }
 
@@ -39,5 +42,11 @@ impl<'a> QueryHandler<'a> {
     #[must_use]
     pub fn neuron(&self, id: Uuid) -> Option<&'a Neuron> {
         self.projection.neuron(id)
+    }
+
+    /// Convenience method to fetch a synapse directly.
+    #[must_use]
+    pub fn synapse(&self, id: Uuid) -> Option<&'a Synapse> {
+        self.projection.synapse(id)
     }
 }

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -27,6 +27,8 @@ pub enum Event {
     RandomSynapseAdded(RandomSynapseAdded),
     /// A randomly chosen synapse was removed from the network.
     RandomSynapseRemoved(RandomSynapseRemoved),
+    /// The weight of an existing synapse was mutated.
+    SynapseWeightMutated(SynapseWeightMutated),
 }
 
 /// Event emitted when a random neuron is added to the network.
@@ -63,4 +65,15 @@ pub struct RandomSynapseAdded {
 pub struct RandomSynapseRemoved {
     /// Identifier of the removed synapse.
     pub synapse_id: Uuid,
+}
+
+/// Event emitted when the weight of a synapse changes due to mutation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SynapseWeightMutated {
+    /// Identifier of the mutated synapse.
+    pub synapse_id: Uuid,
+    /// Previous weight of the synapse before mutation.
+    pub old_weight: f64,
+    /// Newly assigned weight after mutation.
+    pub new_weight: f64,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -9,6 +9,7 @@ mod synapse;
 pub use activation::Activation;
 pub use events::{
     Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+    SynapseWeightMutated,
 };
 pub use network::Network;
 pub use neuron::Neuron;

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use super::events::{
     Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+    SynapseWeightMutated,
 };
 use super::{Neuron, Synapse};
 use uuid::Uuid;
@@ -60,6 +61,9 @@ impl Network {
             Event::RandomSynapseRemoved(e) => {
                 self.apply_random_synapse_removed(e);
             }
+            Event::SynapseWeightMutated(e) => {
+                self.apply_synapse_weight_mutated(e);
+            }
         }
     }
 
@@ -98,6 +102,13 @@ impl Network {
     /// Applies a [`RandomSynapseRemoved`] event to the network state.
     fn apply_random_synapse_removed(&mut self, event: &RandomSynapseRemoved) {
         self.synapses.remove(&event.synapse_id);
+    }
+
+    /// Applies a [`SynapseWeightMutated`] event to the network state.
+    fn apply_synapse_weight_mutated(&mut self, event: &SynapseWeightMutated) {
+        if let Some(synapse) = self.synapses.get_mut(&event.synapse_id) {
+            synapse.weight = event.new_weight;
+        }
     }
 
     /// Convenience method to list all neurons.

--- a/src/infrastructure/projection/network.rs
+++ b/src/infrastructure/projection/network.rs
@@ -40,4 +40,9 @@ impl NetworkProjection {
     pub fn synapses(&self) -> Vec<&Synapse> {
         self.network.synapses()
     }
+
+    /// Fetches a synapse by its identifier.
+    pub fn synapse(&self, id: Uuid) -> Option<&Synapse> {
+        self.network.synapses.get(&id)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ pub mod infrastructure;
 
 pub use application::{
     AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler, AddRandomSynapseCommand,
-    AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler, Query, QueryHandler,
-    QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
-    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
+    AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler,
+    MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
+    MutateRandomSynapseWeightHandler, Query, QueryHandler, QueryResult, RemoveRandomNeuronCommand,
+    RemoveRandomNeuronError, RemoveRandomNeuronHandler, RemoveRandomSynapseCommand,
+    RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };
 pub use domain::{
     Activation, Event, Network as DomainNetwork, Neuron, RandomNeuronAdded, RandomNeuronRemoved,
-    RandomSynapseAdded, RandomSynapseRemoved, Synapse,
+    RandomSynapseAdded, RandomSynapseRemoved, Synapse, SynapseWeightMutated,
 };
 pub use infrastructure::{EventStore, FileEventStore};

--- a/tests/mutate_synapse_weight.rs
+++ b/tests/mutate_synapse_weight.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    application::{
+        MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
+        MutateRandomSynapseWeightHandler, Query, QueryHandler, QueryResult,
+    },
+    domain::{Event, RandomNeuronAdded, RandomSynapseAdded, SynapseWeightMutated},
+    infrastructure::{projection::NetworkProjection, EventStore, FileEventStore},
+    Activation,
+};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_mutate_test_{}.log", Uuid::new_v4()));
+    path
+}
+
+fn seed_two_neurons(store: &mut FileEventStore, n1: Uuid, n2: Uuid) {
+    let events = [
+        Event::RandomNeuronAdded(RandomNeuronAdded {
+            neuron_id: n1,
+            activation: Activation::Identity,
+        }),
+        Event::RandomNeuronAdded(RandomNeuronAdded {
+            neuron_id: n2,
+            activation: Activation::Identity,
+        }),
+    ];
+    for e in &events {
+        store.append(e).unwrap();
+    }
+}
+
+fn seed_synapse(store: &mut FileEventStore, id: Uuid, from: Uuid, to: Uuid) {
+    let event = Event::RandomSynapseAdded(RandomSynapseAdded {
+        synapse_id: id,
+        from,
+        to,
+        weight: 1.0,
+    });
+    store.append(&event).unwrap();
+}
+
+#[test]
+fn mutate_synapse_weight_appends_event() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    seed_two_neurons(&mut store, n1, n2);
+    let syn_id = Uuid::new_v4();
+    seed_synapse(&mut store, syn_id, n1, n2);
+
+    let rng = ChaCha8Rng::seed_from_u64(7);
+    let mut handler = MutateRandomSynapseWeightHandler::new(store, rng).unwrap();
+    let mutated_id = handler
+        .handle(MutateRandomSynapseWeightCommand { std_dev: 0.5 })
+        .unwrap();
+    assert_eq!(mutated_id, syn_id);
+
+    let mut store = handler.store;
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::SynapseWeightMutated(SynapseWeightMutated {
+            synapse_id,
+            old_weight,
+            new_weight,
+        }) => {
+            assert_eq!(*synapse_id, syn_id);
+            assert_eq!(*old_weight, 1.0);
+            assert_ne!(*new_weight, *old_weight);
+            assert_eq!(
+                handler.network.synapses.get(synapse_id).unwrap().weight,
+                *new_weight
+            );
+        }
+        e => panic!("unexpected event {e:?}"),
+    }
+}
+
+#[test]
+fn mutate_synapse_weight_errors_when_empty() {
+    let path = temp_path();
+    let store = FileEventStore::new(path);
+    let rng = ChaCha8Rng::seed_from_u64(8);
+    let mut handler = MutateRandomSynapseWeightHandler::new(store, rng).unwrap();
+    let res = handler.handle(MutateRandomSynapseWeightCommand { std_dev: 0.1 });
+    assert!(matches!(
+        res,
+        Err(MutateRandomSynapseWeightError::NoSynapseAvailable)
+    ));
+}
+
+#[test]
+fn mutate_synapse_weight_event_replay() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    seed_two_neurons(&mut store, n1, n2);
+    let syn_id = Uuid::new_v4();
+    seed_synapse(&mut store, syn_id, n1, n2);
+
+    let rng = ChaCha8Rng::seed_from_u64(9);
+    let mut handler = MutateRandomSynapseWeightHandler::new(store, rng).unwrap();
+    handler
+        .handle(MutateRandomSynapseWeightCommand { std_dev: 0.5 })
+        .unwrap();
+
+    let store = handler.store;
+    let mut replay_store = store;
+    let events = replay_store.load().unwrap();
+    let net = aei_framework::DomainNetwork::hydrate(&events);
+    let last_weight = match events.last().unwrap() {
+        Event::SynapseWeightMutated(SynapseWeightMutated { new_weight, .. }) => *new_weight,
+        e => panic!("unexpected event {e:?}"),
+    };
+    assert_eq!(net.synapses.get(&syn_id).unwrap().weight, last_weight);
+
+    let projection = NetworkProjection::from_events(&events);
+    let handler = QueryHandler::new(&projection);
+    match handler.handle(Query::GetSynapse { id: syn_id }) {
+        QueryResult::Synapse(Some(s)) => assert_eq!(s.weight, last_weight),
+        _ => panic!("synapse not found"),
+    }
+}


### PR DESCRIPTION
## Summary
- mutate synapse weights by Gaussian noise command and handler
- query and projection support fetching synapse weights
- document command→event→apply→projection flow and update glossaries

## Testing
- `cargo test --workspace --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6894641bd5348321b01ae2105fcdf597