### PR TITLE
feat: mutate random neuron activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Random neuron activation mutation through `MutateRandomNeuronActivationCommand` and `MutateRandomNeuronActivationHandler`.
 - Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -38,6 +38,9 @@ State optimized for serving queries, maintained by projections derived from the 
 ### Aggregate
 A domain object that enforces invariants and rebuilds its state by applying events, such as [Network](src/domain/network.rs).
 
+### Activation
+The non-linear function a neuron applies to its input to produce an output.
+
 ### Neuron
 Basic processing unit in the network. Defined in [src/domain/neuron.rs](src/domain/neuron.rs).
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ if let Ok(removed_id) = handler.handle(RemoveRandomNeuronCommand) {
 }
 ```
 
+## Random Neuron Activation Mutation
+
+Mutate the activation function of a randomly selected neuron:
+
+```rust
+use aei_framework::{
+    MutateRandomNeuronActivationCommand, MutateRandomNeuronActivationHandler,
+    FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler =
+    MutateRandomNeuronActivationHandler::new(store, thread_rng()).unwrap();
+if let Ok(mutated_id) = handler.handle(MutateRandomNeuronActivationCommand { exclude_io: false }) {
+    println!("Mutated neuron: {mutated_id}");
+}
+```
+
 ## Random Synapse Addition
 
 Create a synapse between two randomly chosen neurons using the event-sourced

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Random neuron activation mutation through `MutateRandomNeuronActivationCommand` and `MutateRandomNeuronActivationHandler`.
 - Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -47,6 +47,26 @@ if let Ok(removed_id) = handler.handle(RemoveRandomNeuronCommand) {
 }
 ```
 
+## Random Neuron Activation Mutation
+
+Mutate the activation function of a randomly selected neuron:
+
+```rust
+use aei_framework::{
+    MutateRandomNeuronActivationCommand, MutateRandomNeuronActivationHandler,
+    FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler =
+    MutateRandomNeuronActivationHandler::new(store, thread_rng()).unwrap();
+if let Ok(mutated_id) = handler.handle(MutateRandomNeuronActivationCommand { exclude_io: false }) {
+    println!("Mutated neuron: {mutated_id}");
+}
+```
+
 ## Random Synapse Addition
 
 Create a synapse between two randomly chosen neurons using the event-sourced

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -7,6 +7,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Non publié]
 ### Ajouté
+- Mutation aléatoire de l’activation des neurones via `MutateRandomNeuronActivationCommand` et `MutateRandomNeuronActivationHandler`.
 - Mutation aléatoire du poids des synapses via `MutateRandomSynapseWeightCommand` et `MutateRandomSynapseWeightHandler`.
 - Exemple orienté événements et tests de commande de synapse.
 - Entraînement par rétropropagation avec `Network::train` et `Network::predict`

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -61,3 +61,6 @@ Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoir
 
 ### SynapseWeightMutated
 Événement de domaine enregistrant la modification du poids d'une synapse. Émis par `MutateRandomSynapseWeightHandler`.
+
+### Activation
+Fonction non linéaire appliquée à l'entrée d'un neurone pour produire sa sortie.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -46,6 +46,26 @@ if let Ok(removed_id) = handler.handle(RemoveRandomNeuronCommand) {
 }
 ```
 
+## Mutation aléatoire de l’activation d’un neurone
+
+Muter la fonction d’activation d’un neurone choisi aléatoirement :
+
+```rust
+use aei_framework::{
+    MutateRandomNeuronActivationCommand, MutateRandomNeuronActivationHandler,
+    FileEventStore,
+};
+use rand::thread_rng;
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler =
+    MutateRandomNeuronActivationHandler::new(store, thread_rng()).unwrap();
+if let Ok(neuron_id) = handler.handle(MutateRandomNeuronActivationCommand { exclude_io: false }) {
+    println!("Activation mutée : {neuron_id}");
+}
+```
+
 ## Ajout aléatoire de synapse
 
 Créez une synapse entre deux neurones choisis aléatoirement en utilisant le gestionnaire orienté événements :

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@ mod add_random_neuron;
 mod add_random_synapse;
 mod command_handler;
 mod commands;
+mod mutate_random_neuron_activation;
 mod mutate_random_synapse_weight;
 mod queries;
 mod query_handler;
@@ -16,6 +17,10 @@ pub use add_random_synapse::{
 };
 pub use command_handler::CommandHandler;
 pub use commands::Command;
+pub use mutate_random_neuron_activation::{
+    MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
+    MutateRandomNeuronActivationHandler,
+};
 pub use mutate_random_synapse_weight::{
     MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
     MutateRandomSynapseWeightHandler,

--- a/src/application/mutate_random_neuron_activation.rs
+++ b/src/application/mutate_random_neuron_activation.rs
@@ -1,0 +1,123 @@
+//! Command and handler for mutating the activation of a random neuron.
+//!
+//! The mutation replaces the current activation function of a randomly
+//! selected neuron with a different one. The change is persisted as a
+//! [`NeuronActivationMutated`] event and applied to the [`Network`] aggregate.
+
+use rand::{seq::SliceRandom, Rng};
+use uuid::Uuid;
+
+use crate::domain::{Activation, Event, NeuronActivationMutated, Network};
+use crate::infrastructure::EventStore;
+
+/// Command requesting mutation of a random neuron's activation.
+#[derive(Debug, Clone, Copy)]
+pub struct MutateRandomNeuronActivationCommand {
+    /// When true, input and output neurons are excluded from selection.
+    pub exclude_io: bool,
+}
+
+/// Errors that can occur while mutating a neuron's activation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MutateNeuronActivationError {
+    /// No neuron matched the selection criteria.
+    NoEligibleNeuron,
+    /// Persisting the event failed.
+    StorageError,
+}
+
+/// Handles [`MutateRandomNeuronActivationCommand`], emitting and applying
+/// [`NeuronActivationMutated`] events.
+pub struct MutateRandomNeuronActivationHandler<S: EventStore, R: Rng> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state derived from applied events.
+    pub network: Network,
+    rng: R,
+}
+
+impl<S: EventStore, R: Rng> MutateRandomNeuronActivationHandler<S, R> {
+    /// Loads events from the store to initialize the handler.
+    pub fn new(mut store: S, rng: R) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self { store, network, rng })
+    }
+
+    /// Handles the command and returns the identifier of the mutated neuron.
+    ///
+    /// # Errors
+    /// Returns [`MutateNeuronActivationError::NoEligibleNeuron`] if no neuron
+    /// satisfies the selection criteria and
+    /// [`MutateNeuronActivationError::StorageError`] if persisting the event
+    /// fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use aei_framework::{
+    ///     MutateRandomNeuronActivationCommand, MutateRandomNeuronActivationHandler,
+    ///     FileEventStore,
+    /// };
+    /// use rand::thread_rng;
+    /// use std::path::PathBuf;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = FileEventStore::new(PathBuf::from("events.log"));
+    /// let mut handler = MutateRandomNeuronActivationHandler::new(store, thread_rng())?;
+    /// let _ = handler.handle(MutateRandomNeuronActivationCommand { exclude_io: false });
+    /// # Ok(()) }
+    /// ```
+    pub fn handle(
+        &mut self,
+        cmd: MutateRandomNeuronActivationCommand,
+    ) -> Result<Uuid, MutateNeuronActivationError> {
+        let mut candidates: Vec<Uuid> = self.network.neurons.keys().copied().collect();
+        if cmd.exclude_io {
+            candidates.retain(|id| {
+                let has_in = self
+                    .network
+                    .synapses
+                    .values()
+                    .any(|s| s.to == *id);
+                let has_out = self
+                    .network
+                    .synapses
+                    .values()
+                    .any(|s| s.from == *id);
+                has_in && has_out
+            });
+        }
+        let neuron_id = *candidates
+            .choose(&mut self.rng)
+            .ok_or(MutateNeuronActivationError::NoEligibleNeuron)?;
+
+        let old_activation = self
+            .network
+            .neurons
+            .get(&neuron_id)
+            .expect("neuron exists")
+            .activation;
+        let mut activations = vec![
+            Activation::Identity,
+            Activation::Sigmoid,
+            Activation::ReLU,
+            Activation::Tanh,
+        ];
+        activations.retain(|a| *a != old_activation);
+        let new_activation = *activations
+            .choose(&mut self.rng)
+            .expect("activation list is non-empty");
+
+        let event = Event::NeuronActivationMutated(NeuronActivationMutated {
+            neuron_id,
+            old_activation,
+            new_activation,
+        });
+        self.store
+            .append(&event)
+            .map_err(|_| MutateNeuronActivationError::StorageError)?;
+        self.network.apply(&event);
+        Ok(neuron_id)
+    }
+}
+

--- a/src/application/queries.rs
+++ b/src/application/queries.rs
@@ -13,4 +13,6 @@ pub enum Query {
     ListSynapses,
     /// Fetch a synapse by identifier.
     GetSynapse { id: Uuid },
+    /// Fetch the activation function of a neuron by identifier.
+    GetNeuronActivation { id: Uuid },
 }

--- a/src/application/query_handler.rs
+++ b/src/application/query_handler.rs
@@ -1,7 +1,7 @@
 //! Handles read-side queries against the current state.
 
 use crate::application::Query;
-use crate::domain::{Neuron, Synapse};
+use crate::domain::{Activation, Neuron, Synapse};
 use crate::infrastructure::projection::NetworkProjection;
 use uuid::Uuid;
 
@@ -15,6 +15,8 @@ pub enum QueryResult<'a> {
     Synapses(Vec<&'a Synapse>),
     /// Single synapse lookup.
     Synapse(Option<&'a Synapse>),
+    /// Activation lookup.
+    Activation(Option<Activation>),
 }
 
 /// Provides read-only access to the network state.
@@ -35,6 +37,9 @@ impl<'a> QueryHandler<'a> {
             Query::ListNeurons => QueryResult::Neurons(self.projection.neurons()),
             Query::ListSynapses => QueryResult::Synapses(self.projection.synapses()),
             Query::GetSynapse { id } => QueryResult::Synapse(self.projection.synapse(id)),
+            Query::GetNeuronActivation { id } => {
+                QueryResult::Activation(self.projection.activation(id))
+            }
         }
     }
 
@@ -48,5 +53,11 @@ impl<'a> QueryHandler<'a> {
     #[must_use]
     pub fn synapse(&self, id: Uuid) -> Option<&'a Synapse> {
         self.projection.synapse(id)
+    }
+
+    /// Convenience method to fetch a neuron's activation directly.
+    #[must_use]
+    pub fn activation(&self, id: Uuid) -> Option<Activation> {
+        self.projection.activation(id)
     }
 }

--- a/src/domain/activation.rs
+++ b/src/domain/activation.rs
@@ -5,7 +5,7 @@
 //! extending this enum.
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Activation {
     /// Returns the input unchanged.
     #[default]

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -29,6 +29,8 @@ pub enum Event {
     RandomSynapseRemoved(RandomSynapseRemoved),
     /// The weight of an existing synapse was mutated.
     SynapseWeightMutated(SynapseWeightMutated),
+    /// The activation function of a neuron was mutated.
+    NeuronActivationMutated(NeuronActivationMutated),
 }
 
 /// Event emitted when a random neuron is added to the network.
@@ -76,4 +78,15 @@ pub struct SynapseWeightMutated {
     pub old_weight: f64,
     /// Newly assigned weight after mutation.
     pub new_weight: f64,
+}
+
+/// Event emitted when the activation of a neuron changes due to mutation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeuronActivationMutated {
+    /// Identifier of the mutated neuron.
+    pub neuron_id: Uuid,
+    /// Activation function prior to mutation.
+    pub old_activation: Activation,
+    /// Newly assigned activation function.
+    pub new_activation: Activation,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -8,8 +8,8 @@ mod synapse;
 
 pub use activation::Activation;
 pub use events::{
-    Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
-    SynapseWeightMutated,
+    Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
+    RandomSynapseRemoved, SynapseWeightMutated,
 };
 pub use network::Network;
 pub use neuron::Neuron;

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use super::events::{
-    Event, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
-    SynapseWeightMutated,
+    Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
+    RandomSynapseRemoved, SynapseWeightMutated,
 };
 use super::{Neuron, Synapse};
 use uuid::Uuid;
@@ -64,6 +64,9 @@ impl Network {
             Event::SynapseWeightMutated(e) => {
                 self.apply_synapse_weight_mutated(e);
             }
+            Event::NeuronActivationMutated(e) => {
+                self.apply_neuron_activation_mutated(e);
+            }
         }
     }
 
@@ -108,6 +111,13 @@ impl Network {
     fn apply_synapse_weight_mutated(&mut self, event: &SynapseWeightMutated) {
         if let Some(synapse) = self.synapses.get_mut(&event.synapse_id) {
             synapse.weight = event.new_weight;
+        }
+    }
+
+    /// Applies a [`NeuronActivationMutated`] event to the network state.
+    fn apply_neuron_activation_mutated(&mut self, event: &NeuronActivationMutated) {
+        if let Some(neuron) = self.neurons.get_mut(&event.neuron_id) {
+            neuron.activation = event.new_activation;
         }
     }
 

--- a/src/infrastructure/projection/network.rs
+++ b/src/infrastructure/projection/network.rs
@@ -45,4 +45,9 @@ impl NetworkProjection {
     pub fn synapse(&self, id: Uuid) -> Option<&Synapse> {
         self.network.synapses.get(&id)
     }
+
+    /// Fetches the activation function of a neuron by its identifier.
+    pub fn activation(&self, id: Uuid) -> Option<crate::domain::Activation> {
+        self.network.neurons.get(&id).map(|n| n.activation)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,16 @@ pub mod infrastructure;
 pub use application::{
     AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler, AddRandomSynapseCommand,
     AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler,
-    MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
-    MutateRandomSynapseWeightHandler, Query, QueryHandler, QueryResult, RemoveRandomNeuronCommand,
-    RemoveRandomNeuronError, RemoveRandomNeuronHandler, RemoveRandomSynapseCommand,
-    RemoveRandomSynapseError, RemoveRandomSynapseHandler,
+    MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
+    MutateRandomNeuronActivationHandler, MutateRandomSynapseWeightCommand,
+    MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query,
+    QueryHandler, QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError,
+    RemoveRandomNeuronHandler, RemoveRandomSynapseCommand, RemoveRandomSynapseError,
+    RemoveRandomSynapseHandler,
 };
 pub use domain::{
     Activation, Event, Network as DomainNetwork, Neuron, RandomNeuronAdded, RandomNeuronRemoved,
     RandomSynapseAdded, RandomSynapseRemoved, Synapse, SynapseWeightMutated,
+    NeuronActivationMutated,
 };
 pub use infrastructure::{EventStore, FileEventStore};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,13 @@ pub use application::{
     AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler,
     MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
     MutateRandomNeuronActivationHandler, MutateRandomSynapseWeightCommand,
-    MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query,
-    QueryHandler, QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError,
-    RemoveRandomNeuronHandler, RemoveRandomSynapseCommand, RemoveRandomSynapseError,
-    RemoveRandomSynapseHandler,
+    MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query, QueryHandler,
+    QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };
 pub use domain::{
-    Activation, Event, Network as DomainNetwork, Neuron, RandomNeuronAdded, RandomNeuronRemoved,
-    RandomSynapseAdded, RandomSynapseRemoved, Synapse, SynapseWeightMutated,
-    NeuronActivationMutated,
+    Activation, Event, Network as DomainNetwork, Neuron, NeuronActivationMutated,
+    RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved, Synapse,
+    SynapseWeightMutated,
 };
 pub use infrastructure::{EventStore, FileEventStore};

--- a/tests/mutate_neuron_activation.rs
+++ b/tests/mutate_neuron_activation.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    application::{
+        MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
+        MutateRandomNeuronActivationHandler, Query, QueryHandler, QueryResult,
+    },
+    domain::{Activation, Event, NeuronActivationMutated, RandomNeuronAdded},
+    infrastructure::{projection::NetworkProjection, EventStore, FileEventStore},
+};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_mutate_act_{}.log", Uuid::new_v4()));
+    path
+}
+
+fn seed_neuron(store: &mut FileEventStore, id: Uuid, activation: Activation) {
+    let event = Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation });
+    store.append(&event).unwrap();
+}
+
+#[test]
+fn mutate_neuron_activation_appends_event() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let neuron_id = Uuid::new_v4();
+    seed_neuron(&mut store, neuron_id, Activation::Identity);
+
+    let rng = ChaCha8Rng::seed_from_u64(1);
+    let mut handler = MutateRandomNeuronActivationHandler::new(store, rng).unwrap();
+    let mutated_id = handler
+        .handle(MutateRandomNeuronActivationCommand { exclude_io: false })
+        .unwrap();
+    assert_eq!(mutated_id, neuron_id);
+
+    let mut store = handler.store;
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::NeuronActivationMutated(NeuronActivationMutated { neuron_id: id, old_activation, new_activation }) => {
+            assert_eq!(*id, neuron_id);
+            assert_eq!(*old_activation, Activation::Identity);
+            assert_ne!(*old_activation, *new_activation);
+            assert_eq!(
+                handler.network.neurons.get(id).unwrap().activation,
+                *new_activation
+            );
+        }
+        e => panic!("unexpected event {e:?}"),
+    }
+
+    let projection = NetworkProjection::from_events(&events);
+    let handler = QueryHandler::new(&projection);
+    match handler.handle(Query::GetNeuronActivation { id: neuron_id }) {
+        QueryResult::Activation(Some(a)) => {
+            if let Event::NeuronActivationMutated(NeuronActivationMutated { new_activation, .. }) = events.last().unwrap() {
+                assert_eq!(*new_activation, a);
+            }
+        }
+        _ => panic!("activation not found"),
+    }
+}
+
+#[test]
+fn mutate_neuron_activation_errors_when_no_eligible() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path);
+    let neuron_id = Uuid::new_v4();
+    seed_neuron(&mut store, neuron_id, Activation::Identity);
+
+    let rng = ChaCha8Rng::seed_from_u64(2);
+    let mut handler = MutateRandomNeuronActivationHandler::new(store, rng).unwrap();
+    let res = handler.handle(MutateRandomNeuronActivationCommand { exclude_io: true });
+    assert!(matches!(res, Err(MutateNeuronActivationError::NoEligibleNeuron)));
+}
+
+#[test]
+fn mutate_neuron_activation_event_replay() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let neuron_id = Uuid::new_v4();
+    seed_neuron(&mut store, neuron_id, Activation::Identity);
+
+    let rng = ChaCha8Rng::seed_from_u64(3);
+    let mut handler = MutateRandomNeuronActivationHandler::new(store, rng).unwrap();
+    handler
+        .handle(MutateRandomNeuronActivationCommand { exclude_io: false })
+        .unwrap();
+    let store = handler.store;
+    let mut replay_store = store;
+    let events = replay_store.load().unwrap();
+    let net = aei_framework::DomainNetwork::hydrate(&events);
+    let last_activation = match events.last().unwrap() {
+        Event::NeuronActivationMutated(NeuronActivationMutated { new_activation, .. }) => *new_activation,
+        e => panic!("unexpected event {e:?}"),
+    };
+    assert_eq!(net.neurons.get(&neuron_id).unwrap().activation, last_activation);
+
+    let projection = NetworkProjection::from_events(&events);
+    let handler = QueryHandler::new(&projection);
+    match handler.handle(Query::GetNeuronActivation { id: neuron_id }) {
+        QueryResult::Activation(Some(a)) => assert_eq!(a, last_activation),
+        _ => panic!("activation not found"),
+    }
+}


### PR DESCRIPTION
## Summary
- allow mutating the activation of a random neuron via `MutateRandomNeuronActivationCommand`
- emit `NeuronActivationMutated` events and update projections
- expose `GetNeuronActivation` query to inspect current activation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895a8a84a288321bd2c831ebba3eb6f