### PR TITLE
feat: add curiosity score

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -67,3 +67,6 @@ Command that mutates the weight of a randomly selected synapse by adding Gaussia
 
 ### SynapseWeightMutated
 Domain event recording a change in a synapse's weight. Emitted by `MutateRandomSynapseWeightHandler`.
+
+### Curiosity Score
+Metric representing the exploratory potential of a neuron or synapse. Recomputed via `RecalculateCuriosityScoreCommand` and stored through `CuriosityScoreUpdated` events.

--- a/docs/en/CURIOSITY_SCORE.md
+++ b/docs/en/CURIOSITY_SCORE.md
@@ -1,0 +1,7 @@
+# Curiosity Score
+
+The *Curiosity Score* measures how novel or promising a neuron or synapse is during exploration. It is computed from the history of events and currently uses a simple rarity-based formula. Scores are stored inside the domain entities and can be queried through a dedicated projection.
+
+## Recalculation
+
+Use `RecalculateCuriosityScoreCommand` to recompute the score for specific identifiers or for the entire network. A `CuriosityScoreUpdated` event is emitted for each updated element.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -153,6 +153,27 @@ let qh = MemoryQueryHandler::new(&projection);
 let _entries = qh.handle(MemoryQuery::GetMemoryState);
 ```
 
+## Curiosity Score
+
+Evaluate exploratory potential of network components:
+
+```rust
+use aei_framework::{
+    CuriosityScope, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
+    FileEventStore,
+};
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = RecalculateCuriosityScoreHandler::new(store).unwrap();
+handler
+    .handle(RecalculateCuriosityScoreCommand {
+        target_ids: vec![],
+        scope: CuriosityScope::All,
+    })
+    .unwrap();
+```
+
 ## Logging
 
 The framework emits informational messages using the [`log`](https://docs.rs/log) crate. To see these logs, initialize a logger implementation such as [`env_logger`](https://docs.rs/env_logger) in your application:

--- a/docs/fr/CURIOSITY_SCORE.md
+++ b/docs/fr/CURIOSITY_SCORE.md
@@ -1,0 +1,7 @@
+# Score de Curiosité
+
+Le *Score de Curiosité* mesure le caractère novateur ou prometteur d'un neurone ou d'une synapse durant l'exploration. Il est calculé à partir de l'historique des événements et utilise actuellement une formule simple basée sur la rareté. Les scores sont stockés dans les entités de domaine et peuvent être interrogés via une projection dédiée.
+
+## Recalcul
+
+Utilisez `RecalculateCuriosityScoreCommand` pour recalculer le score pour des identifiants spécifiques ou pour l'ensemble du réseau. Un événement `CuriosityScoreUpdated` est émis pour chaque élément mis à jour.

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -67,3 +67,6 @@ Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoir
 
 ### Activation
 Fonction non linéaire appliquée à l'entrée d'un neurone pour produire sa sortie.
+
+### Score de curiosité
+Métrique représentant le potentiel exploratoire d'un neurone ou d'une synapse. Recalculé via `RecalculateCuriosityScoreCommand` et persisté par des événements `CuriosityScoreUpdated`.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -151,6 +151,27 @@ let qh = MemoryQueryHandler::new(&projection);
 let _entries = qh.handle(MemoryQuery::GetMemoryState);
 ```
 
+## Score de curiosité
+
+Évaluez le potentiel exploratoire des composants du réseau :
+
+```rust
+use aei_framework::{
+    CuriosityScope, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
+    FileEventStore,
+};
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = RecalculateCuriosityScoreHandler::new(store).unwrap();
+handler
+    .handle(RecalculateCuriosityScoreCommand {
+        target_ids: vec![],
+        scope: CuriosityScope::All,
+    })
+    .unwrap();
+```
+
 ## Journalisation
 
 Le framework émet des messages d'information via la crate [`log`](https://docs.rs/log). Pour afficher ces journaux, initialisez une implémentation de logger comme [`env_logger`](https://docs.rs/env_logger) dans votre application :

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -7,9 +7,9 @@ mod commands;
 pub mod memory;
 mod mutate_random_neuron_activation;
 mod mutate_random_synapse_weight;
-mod recalculate_curiosity_score;
 mod queries;
 mod query_handler;
+mod recalculate_curiosity_score;
 mod remove_random_neuron;
 mod remove_random_synapse;
 
@@ -27,11 +27,11 @@ pub use mutate_random_synapse_weight::{
     MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
     MutateRandomSynapseWeightHandler,
 };
+pub use queries::Query;
+pub use query_handler::{QueryHandler, QueryResult};
 pub use recalculate_curiosity_score::{
     CuriosityScope, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
 };
-pub use queries::Query;
-pub use query_handler::{QueryHandler, QueryResult};
 pub use remove_random_neuron::{
     RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
 };

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -7,6 +7,7 @@ mod commands;
 pub mod memory;
 mod mutate_random_neuron_activation;
 mod mutate_random_synapse_weight;
+mod recalculate_curiosity_score;
 mod queries;
 mod query_handler;
 mod remove_random_neuron;
@@ -25,6 +26,9 @@ pub use mutate_random_neuron_activation::{
 pub use mutate_random_synapse_weight::{
     MutateRandomSynapseWeightCommand, MutateRandomSynapseWeightError,
     MutateRandomSynapseWeightHandler,
+};
+pub use recalculate_curiosity_score::{
+    CuriosityScope, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
 };
 pub use queries::Query;
 pub use query_handler::{QueryHandler, QueryResult};

--- a/src/application/recalculate_curiosity_score.rs
+++ b/src/application/recalculate_curiosity_score.rs
@@ -96,13 +96,11 @@ impl<S: EventStore> RecalculateCuriosityScoreHandler<S> {
         match event {
             Event::RandomNeuronAdded(e) => e.neuron_id == id,
             Event::RandomNeuronRemoved(e) => e.neuron_id == id,
-            Event::SynapseCreated { id: sid, from, to, .. } => {
-                *sid == id || *from == id || *to == id
-            }
+            Event::SynapseCreated {
+                id: sid, from, to, ..
+            } => *sid == id || *from == id || *to == id,
             Event::SynapseRemoved { id: sid } => *sid == id,
-            Event::RandomSynapseAdded(e) => {
-                e.synapse_id == id || e.from == id || e.to == id
-            }
+            Event::RandomSynapseAdded(e) => e.synapse_id == id || e.from == id || e.to == id,
             Event::RandomSynapseRemoved(e) => e.synapse_id == id,
             Event::SynapseWeightMutated(e) => e.synapse_id == id,
             Event::NeuronActivationMutated(e) => e.neuron_id == id,

--- a/src/application/recalculate_curiosity_score.rs
+++ b/src/application/recalculate_curiosity_score.rs
@@ -1,0 +1,133 @@
+//! Command and handler to recalculate curiosity scores.
+
+use uuid::Uuid;
+
+use crate::domain::{CuriosityScoreUpdated, Event, Network};
+use crate::infrastructure::EventStore;
+
+/// Scope of targets whose curiosity score should be recomputed.
+#[derive(Debug, Clone, Copy)]
+pub enum CuriosityScope {
+    /// Only the provided neuron identifiers.
+    Neuron,
+    /// Only the provided synapse identifiers.
+    Synapse,
+    /// All neurons and synapses currently in the network.
+    All,
+}
+
+/// Command requesting curiosity score recalculation.
+#[derive(Debug, Clone)]
+pub struct RecalculateCuriosityScoreCommand {
+    /// Identifiers of targets to update.
+    pub target_ids: Vec<Uuid>,
+    /// Scope describing the type of targets.
+    pub scope: CuriosityScope,
+}
+
+/// Handles [`RecalculateCuriosityScoreCommand`].
+pub struct RecalculateCuriosityScoreHandler<S: EventStore> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state reconstructed from events.
+    pub network: Network,
+}
+
+impl<S: EventStore> RecalculateCuriosityScoreHandler<S> {
+    /// Loads events from the store to initialize the handler.
+    pub fn new(mut store: S) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self { store, network })
+    }
+
+    /// Recomputes curiosity scores for the requested targets.
+    pub fn handle(
+        &mut self,
+        cmd: RecalculateCuriosityScoreCommand,
+    ) -> Result<Vec<Event>, S::Error> {
+        let events = self.store.load()?; // full history for analysis
+        let targets = self.resolve_targets(cmd);
+        let mut emitted = Vec::new();
+        for id in targets {
+            let old = self
+                .network
+                .neurons
+                .get(&id)
+                .map(|n| n.curiosity_score)
+                .or_else(|| self.network.synapses.get(&id).map(|s| s.curiosity_score))
+                .unwrap_or_default();
+            let new_score = Self::compute_score(&events, id);
+            if (new_score - old).abs() > f64::EPSILON {
+                let event = Event::CuriosityScoreUpdated(CuriosityScoreUpdated {
+                    target_id: id,
+                    old_score: old,
+                    new_score,
+                });
+                self.store.append(&event)?;
+                self.network.apply(&event);
+                emitted.push(event);
+            }
+        }
+        Ok(emitted)
+    }
+
+    fn resolve_targets(&self, cmd: RecalculateCuriosityScoreCommand) -> Vec<Uuid> {
+        match cmd.scope {
+            CuriosityScope::Neuron => cmd.target_ids,
+            CuriosityScope::Synapse => cmd.target_ids,
+            CuriosityScope::All => self
+                .network
+                .neurons
+                .keys()
+                .chain(self.network.synapses.keys())
+                .copied()
+                .collect(),
+        }
+    }
+
+    /// Computes a simple curiosity score based on event rarity.
+    fn compute_score(events: &[Event], id: Uuid) -> f64 {
+        let occurrences = events.iter().filter(|e| Self::touches(e, id)).count();
+        1.0 / (1.0 + occurrences as f64)
+    }
+
+    fn touches(event: &Event, id: Uuid) -> bool {
+        match event {
+            Event::RandomNeuronAdded(e) => e.neuron_id == id,
+            Event::RandomNeuronRemoved(e) => e.neuron_id == id,
+            Event::SynapseCreated { id: sid, from, to, .. } => {
+                *sid == id || *from == id || *to == id
+            }
+            Event::SynapseRemoved { id: sid } => *sid == id,
+            Event::RandomSynapseAdded(e) => {
+                e.synapse_id == id || e.from == id || e.to == id
+            }
+            Event::RandomSynapseRemoved(e) => e.synapse_id == id,
+            Event::SynapseWeightMutated(e) => e.synapse_id == id,
+            Event::NeuronActivationMutated(e) => e.neuron_id == id,
+            Event::CuriosityScoreUpdated(e) => e.target_id == id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{RandomNeuronAdded, RandomNeuronRemoved};
+
+    #[test]
+    fn compute_score_decreases_with_occurrences() {
+        let id = Uuid::new_v4();
+        let events = vec![
+            Event::RandomNeuronAdded(RandomNeuronAdded {
+                neuron_id: id,
+                activation: crate::domain::Activation::Identity,
+            }),
+            Event::RandomNeuronRemoved(RandomNeuronRemoved { neuron_id: id }),
+        ];
+        let score =
+            RecalculateCuriosityScoreHandler::<crate::FileEventStore>::compute_score(&events, id);
+        assert!(score < 1.0);
+    }
+}

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -31,6 +31,8 @@ pub enum Event {
     SynapseWeightMutated(SynapseWeightMutated),
     /// The activation function of a neuron was mutated.
     NeuronActivationMutated(NeuronActivationMutated),
+    /// The curiosity score of a neuron or synapse was updated.
+    CuriosityScoreUpdated(CuriosityScoreUpdated),
 }
 
 /// Event emitted when a random neuron is added to the network.
@@ -89,4 +91,15 @@ pub struct NeuronActivationMutated {
     pub old_activation: Activation,
     /// Newly assigned activation function.
     pub new_activation: Activation,
+}
+
+/// Event emitted when a curiosity score changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CuriosityScoreUpdated {
+    /// Identifier of the neuron or synapse.
+    pub target_id: Uuid,
+    /// Previous curiosity score.
+    pub old_score: f64,
+    /// Newly computed curiosity score.
+    pub new_score: f64,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -9,8 +9,8 @@ mod synapse;
 
 pub use activation::Activation;
 pub use events::{
-    Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
-    RandomSynapseRemoved, SynapseWeightMutated,
+    CuriosityScoreUpdated, Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved,
+    RandomSynapseAdded, RandomSynapseRemoved, SynapseWeightMutated,
 };
 pub use memory::{
     AdaptiveMemory, MemoryEntry, MemoryEntryAdded, MemoryEntryRemoved, MemoryEvent, MemoryPruned,

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use super::events::{
-    Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
-    RandomSynapseRemoved, SynapseWeightMutated,
+    CuriosityScoreUpdated, Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved,
+    RandomSynapseAdded, RandomSynapseRemoved, SynapseWeightMutated,
 };
 use super::{Neuron, Synapse};
 use uuid::Uuid;
@@ -67,6 +67,9 @@ impl Network {
             Event::NeuronActivationMutated(e) => {
                 self.apply_neuron_activation_mutated(e);
             }
+            Event::CuriosityScoreUpdated(e) => {
+                self.apply_curiosity_score_updated(e);
+            }
         }
     }
 
@@ -118,6 +121,15 @@ impl Network {
     fn apply_neuron_activation_mutated(&mut self, event: &NeuronActivationMutated) {
         if let Some(neuron) = self.neurons.get_mut(&event.neuron_id) {
             neuron.activation = event.new_activation;
+        }
+    }
+
+    /// Applies a [`CuriosityScoreUpdated`] event to the network state.
+    fn apply_curiosity_score_updated(&mut self, event: &CuriosityScoreUpdated) {
+        if let Some(neuron) = self.neurons.get_mut(&event.target_id) {
+            neuron.curiosity_score = event.new_score;
+        } else if let Some(synapse) = self.synapses.get_mut(&event.target_id) {
+            synapse.curiosity_score = event.new_score;
         }
     }
 

--- a/src/domain/neuron.rs
+++ b/src/domain/neuron.rs
@@ -16,6 +16,8 @@ pub struct Neuron {
     pub value: f64,
     /// Activation function used by this neuron.
     pub activation: Activation,
+    /// Current curiosity score guiding exploration.
+    pub curiosity_score: f64,
 }
 
 impl Neuron {
@@ -26,6 +28,7 @@ impl Neuron {
             id: Uuid::new_v4(),
             value: 0.0,
             activation,
+            curiosity_score: 0.0,
         }
     }
 
@@ -35,6 +38,12 @@ impl Neuron {
             id,
             value: 0.0,
             activation,
+            curiosity_score: 0.0,
         }
+    }
+
+    /// Updates the curiosity score of the neuron.
+    pub fn update_curiosity_score(&mut self, score: f64) {
+        self.curiosity_score = score;
     }
 }

--- a/src/domain/synapse.rs
+++ b/src/domain/synapse.rs
@@ -16,6 +16,8 @@ pub struct Synapse {
     pub to: Uuid,
     /// Weight applied during propagation.
     pub weight: f64,
+    /// Curiosity score evaluating exploratory potential.
+    pub curiosity_score: f64,
 }
 
 impl Synapse {
@@ -26,6 +28,7 @@ impl Synapse {
             from,
             to,
             weight,
+            curiosity_score: 0.0,
         }
     }
 
@@ -36,6 +39,12 @@ impl Synapse {
             from,
             to,
             weight,
+            curiosity_score: 0.0,
         }
+    }
+
+    /// Updates the curiosity score of the synapse.
+    pub fn update_curiosity_score(&mut self, score: f64) {
+        self.curiosity_score = score;
     }
 }

--- a/src/infrastructure/projection/curiosity.rs
+++ b/src/infrastructure/projection/curiosity.rs
@@ -1,0 +1,38 @@
+//! Projection storing curiosity scores for quick lookup.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::domain::{CuriosityScoreUpdated, Event};
+
+/// Read model mapping identifiers to curiosity scores.
+#[derive(Debug, Default)]
+pub struct CuriosityScoreProjection {
+    scores: HashMap<Uuid, f64>,
+}
+
+impl CuriosityScoreProjection {
+    /// Builds the projection by replaying events.
+    #[must_use]
+    pub fn from_events(events: &[Event]) -> Self {
+        let mut proj = Self::default();
+        for event in events {
+            proj.apply(event);
+        }
+        proj
+    }
+
+    /// Applies a new event to update a score.
+    pub fn apply(&mut self, event: &Event) {
+        if let Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id, new_score, .. }) = event {
+            self.scores.insert(*target_id, *new_score);
+        }
+    }
+
+    /// Returns the curiosity score for the given identifier.
+    #[must_use]
+    pub fn get(&self, id: Uuid) -> Option<f64> {
+        self.scores.get(&id).copied()
+    }
+}

--- a/src/infrastructure/projection/curiosity.rs
+++ b/src/infrastructure/projection/curiosity.rs
@@ -25,7 +25,12 @@ impl CuriosityScoreProjection {
 
     /// Applies a new event to update a score.
     pub fn apply(&mut self, event: &Event) {
-        if let Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id, new_score, .. }) = event {
+        if let Event::CuriosityScoreUpdated(CuriosityScoreUpdated {
+            target_id,
+            new_score,
+            ..
+        }) = event
+        {
             self.scores.insert(*target_id, *new_score);
         }
     }

--- a/src/infrastructure/projection/mod.rs
+++ b/src/infrastructure/projection/mod.rs
@@ -1,9 +1,9 @@
 //! Projections translating event streams into queryable read models.
 
+mod curiosity;
 mod memory_projection;
 mod network;
-mod curiosity;
 
+pub use curiosity::CuriosityScoreProjection;
 pub use memory_projection::MemoryProjection;
 pub use network::NetworkProjection;
-pub use curiosity::CuriosityScoreProjection;

--- a/src/infrastructure/projection/mod.rs
+++ b/src/infrastructure/projection/mod.rs
@@ -2,6 +2,8 @@
 
 mod memory_projection;
 mod network;
+mod curiosity;
 
 pub use memory_projection::MemoryProjection;
 pub use network::NetworkProjection;
+pub use curiosity::CuriosityScoreProjection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,18 +13,18 @@ pub use application::memory::{
 };
 pub use application::{
     AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler, AddRandomSynapseCommand,
-    AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler,
+    AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler, CuriosityScope,
     MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
     MutateRandomNeuronActivationHandler, MutateRandomSynapseWeightCommand,
     MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query, QueryHandler,
     QueryResult, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
     RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
-    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler, CuriosityScope,
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };
 pub use domain::{
-    Activation, AdaptiveMemory, Event, MemoryEntry, MemoryEntryAdded, MemoryEntryRemoved,
-    MemoryEvent, MemoryPruned, MemoryScoreUpdated, Network as DomainNetwork, Neuron,
-    NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
-    RandomSynapseRemoved, Synapse, SynapseWeightMutated, CuriosityScoreUpdated,
+    Activation, AdaptiveMemory, CuriosityScoreUpdated, Event, MemoryEntry, MemoryEntryAdded,
+    MemoryEntryRemoved, MemoryEvent, MemoryPruned, MemoryScoreUpdated, Network as DomainNetwork,
+    Neuron, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
+    RandomSynapseRemoved, Synapse, SynapseWeightMutated,
 };
 pub use infrastructure::{EventStore, FileEventStore, FileMemoryEventStore, MemoryEventStore};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,14 @@ pub use application::{
     MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
     MutateRandomNeuronActivationHandler, MutateRandomSynapseWeightCommand,
     MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query, QueryHandler,
-    QueryResult, RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
-    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
+    QueryResult, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
+    RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
+    RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler, CuriosityScope,
 };
 pub use domain::{
     Activation, AdaptiveMemory, Event, MemoryEntry, MemoryEntryAdded, MemoryEntryRemoved,
     MemoryEvent, MemoryPruned, MemoryScoreUpdated, Network as DomainNetwork, Neuron,
     NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
-    RandomSynapseRemoved, Synapse, SynapseWeightMutated,
+    RandomSynapseRemoved, Synapse, SynapseWeightMutated, CuriosityScoreUpdated,
 };
 pub use infrastructure::{EventStore, FileEventStore, FileMemoryEventStore, MemoryEventStore};

--- a/tests/curiosity_score.rs
+++ b/tests/curiosity_score.rs
@@ -1,10 +1,9 @@
 use std::path::PathBuf;
 
 use aei_framework::{
-    Activation, CuriosityScope, Event, FileEventStore, RecalculateCuriosityScoreCommand,
-    RecalculateCuriosityScoreHandler, CuriosityScoreUpdated, EventStore,
-    RandomNeuronAdded, DomainNetwork,
-    infrastructure::projection::CuriosityScoreProjection,
+    infrastructure::projection::CuriosityScoreProjection, Activation, CuriosityScope,
+    CuriosityScoreUpdated, DomainNetwork, Event, EventStore, FileEventStore, RandomNeuronAdded,
+    RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
 };
 use uuid::Uuid;
 

--- a/tests/curiosity_score.rs
+++ b/tests/curiosity_score.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    Activation, CuriosityScope, Event, FileEventStore, RecalculateCuriosityScoreCommand,
+    RecalculateCuriosityScoreHandler, CuriosityScoreUpdated, EventStore,
+    RandomNeuronAdded, DomainNetwork,
+    infrastructure::projection::CuriosityScoreProjection,
+};
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_curiosity_test_{}.log", Uuid::new_v4()));
+    path
+}
+
+#[test]
+fn curiosity_score_event_and_projection() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let neuron_id = Uuid::new_v4();
+    let event = Event::RandomNeuronAdded(RandomNeuronAdded {
+        neuron_id,
+        activation: Activation::Identity,
+    });
+    store.append(&event).unwrap();
+
+    let mut handler = RecalculateCuriosityScoreHandler::new(store).unwrap();
+    let cmd = RecalculateCuriosityScoreCommand {
+        target_ids: vec![neuron_id],
+        scope: CuriosityScope::Neuron,
+    };
+    let events = handler.handle(cmd).unwrap();
+    assert!(matches!(
+        events.first(),
+        Some(Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id, .. })) if *target_id == neuron_id
+    ));
+    let mut store = handler.store;
+    let events = store.load().unwrap();
+    let projection = CuriosityScoreProjection::from_events(&events);
+    let score = projection.get(neuron_id).expect("score present");
+    assert!(score <= 1.0);
+    let net = DomainNetwork::hydrate(&events);
+    let neuron = net.neurons.get(&neuron_id).expect("neuron exists");
+    assert_eq!(neuron.curiosity_score, score);
+}


### PR DESCRIPTION
## Summary
- track curiosity_score on neurons and synapses
- add command, event, and projection to recalculate curiosity
- document curiosity score in English and French

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895b779fe908321a51f3a1882970889