### PR TITLE
Add memory example

### DIFF
--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -1,0 +1,55 @@
+//! Demonstrates basic memory operations using a temporary file-backed event store.
+//!
+//! This example shows how to:
+//! - insert a memory entry with `AddMemoryEntryHandler`.
+//! - update its score using `UpdateMemoryScoreHandler`.
+//! - query the top entries through `MemoryProjection`.
+
+use aei_framework::{
+    application::memory::{
+        AddMemoryEntryCommand, AddMemoryEntryHandler, UpdateMemoryScoreCommand,
+        UpdateMemoryScoreHandler,
+    },
+    infrastructure::{projection::MemoryProjection, FileMemoryEventStore},
+    MemoryEventStore,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Runs the memory example.
+fn main() {
+    env_logger::init();
+    let path = std::env::temp_dir().join(format!("aei_memory_{}.log", Uuid::new_v4()));
+    let store = FileMemoryEventStore::new(path.clone());
+
+    // Insert a new memory entry.
+    let mut add = AddMemoryEntryHandler::new(store, 10).expect("store");
+    let entry_id = add
+        .handle(AddMemoryEntryCommand {
+            event_type: "interaction".into(),
+            payload: json!({"msg": "hello"}),
+            score: 0.7,
+        })
+        .expect("add entry");
+
+    // Update the score of that entry.
+    let store = add.store;
+    let mut update = UpdateMemoryScoreHandler::new(store, 10).expect("store");
+    update
+        .handle(UpdateMemoryScoreCommand {
+            entry_id,
+            new_score: 0.9,
+        })
+        .expect("update score");
+
+    // Build a projection and query the top entry.
+    let mut store = update.store;
+    let events = store.load().expect("load events");
+    let projection = MemoryProjection::from_events(10, &events);
+    if let Some(entry) = projection.top_entries(1).first() {
+        println!("Top entry: {} with score {}", entry.id, entry.score);
+    }
+
+    // Clean up the temporary file.
+    std::fs::remove_file(path).expect("cleanup");
+}


### PR DESCRIPTION
## Summary
- add memory example using file-backed event store

## Testing
- `cargo run --example memory`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68960b8de1d48321b9eb21c3a5a54d9e