### PR TITLE
refactor: introduce shared network handler base

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -29,6 +29,9 @@ Architectural pattern in which state is derived from a log of events rather than
 ### Command Handler
 Component that validates and executes a command, emitting one or more events. Examples include [AddRandomNeuronHandler](src/application/add_random_neuron.rs) and [RemoveRandomNeuronHandler](src/application/remove_random_neuron.rs).
 
+### NetworkHandlerBase
+Shared structure bundling an event store, a hydrated [`Network`](src/domain/network.rs), and a random number generator for command handlers operating on networks.
+
 ### Query Handler
 Component that serves a query by reading from a projection or read model. See [src/application/query_handler.rs](src/application/query_handler.rs).
 

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -29,6 +29,9 @@ Modèle architectural où l'état est dérivé d'un journal d'événements plut�
 ### Gestionnaire de commande
 Composant qui valide et exécute une commande, émettant un ou plusieurs événements. Exemples : [AddRandomNeuronHandler](../../src/application/add_random_neuron.rs) et [RemoveRandomNeuronHandler](../../src/application/remove_random_neuron.rs).
 
+### NetworkHandlerBase
+Structure de base regroupant le magasin d'événements, le réseau hydraté et le générateur de nombres aléatoires pour les gestionnaires de commandes opérant sur les réseaux.
+
 ### Gestionnaire de requête
 Composant qui sert une requête en lisant depuis une projection ou un modèle de lecture. Voir [src/application/query_handler.rs](../../src/application/query_handler.rs).
 
@@ -59,8 +62,8 @@ Commande qui supprime un neurone choisi aléatoirement du réseau. Implémentée
 ### AddRandomSynapseCommand
 Commande qui crée une synapse entre deux neurones choisis aléatoirement. Implémentée dans [src/application/add_random_synapse.rs](../../src/application/add_random_synapse.rs).
 
-## RemoveRandomSynapseCommand
-Commande demandant la suppression d'une synapse aléatoire du réseau. Implémentée dans [src/application/add_random_synapse.rs](../../src/application/remove_random_synapse.rs).
+### RemoveRandomSynapseCommand
+Commande demandant la suppression d'une synapse aléatoire du réseau. Implémentée dans [src/application/remove_random_synapse.rs](../../src/application/remove_random_synapse.rs).
 
 ### MutateRandomSynapseWeightCommand
 Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoirement. Implémentée dans [src/application/mutate_random_synapse_weight.rs](../../src/application/mutate_random_synapse_weight.rs).

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -20,7 +20,7 @@ fn main() {
         .expect("second neuron");
 
     // Reuse the same event store to add a synapse between them.
-    let store = add_neuron.store;
+    let store = add_neuron.base.store;
     let mut add_synapse = AddRandomSynapseHandler::new(store, thread_rng()).expect("store");
     let syn = add_synapse
         .handle(AddRandomSynapseCommand)
@@ -28,7 +28,7 @@ fn main() {
     println!("Added neurons {n1} and {n2} with synapse {syn}");
 
     // Build a projection and query neuron information.
-    let mut store = add_synapse.store;
+    let mut store = add_synapse.base.store;
     let events = store.load().expect("load events");
     let projection = NetworkProjection::from_events(&events);
     let handler = QueryHandler::new(&projection);

--- a/src/application/common.rs
+++ b/src/application/common.rs
@@ -1,0 +1,45 @@
+//! Common base struct for network command handlers leveraging randomness.
+//!
+//! This base aggregates an event store, the hydrated network state, and a
+//! random number generator. It provides a constructor that loads events from
+//! the store and rebuilds the network so handlers only need to focus on their
+//! specific logic.
+//!
+//! # Examples
+//! ```
+//! use aei_framework::{application::NetworkHandlerBase, FileEventStore};
+//! use rand::thread_rng;
+//! use std::path::PathBuf;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let store = FileEventStore::new(PathBuf::from("events.log"));
+//! let _base = NetworkHandlerBase::new(store, thread_rng())?;
+//! # Ok(()) }
+//! ```
+use rand::Rng;
+
+use crate::domain::Network;
+use crate::infrastructure::EventStore;
+
+/// Shared state for handlers operating on a [`Network`] with randomness.
+pub struct NetworkHandlerBase<S: EventStore, R: Rng> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state derived from applied events.
+    pub network: Network,
+    /// Random number generator.
+    pub rng: R,
+}
+
+impl<S: EventStore, R: Rng> NetworkHandlerBase<S, R> {
+    /// Loads events from the store and initializes the base handler.
+    pub fn new(mut store: S, rng: R) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self {
+            store,
+            network,
+            rng,
+        })
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@ mod add_random_neuron;
 mod add_random_synapse;
 mod command_handler;
 mod commands;
+mod common;
 pub mod memory;
 mod mutate_random_neuron_activation;
 mod mutate_random_synapse_weight;
@@ -19,6 +20,7 @@ pub use add_random_synapse::{
 };
 pub use command_handler::CommandHandler;
 pub use commands::Command;
+pub use common::NetworkHandlerBase;
 pub use mutate_random_neuron_activation::{
     MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
     MutateRandomNeuronActivationHandler,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ pub use application::{
     AddRandomSynapseError, AddRandomSynapseHandler, Command, CommandHandler, CuriosityScope,
     MutateNeuronActivationError, MutateRandomNeuronActivationCommand,
     MutateRandomNeuronActivationHandler, MutateRandomSynapseWeightCommand,
-    MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, Query, QueryHandler,
-    QueryResult, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
+    MutateRandomSynapseWeightError, MutateRandomSynapseWeightHandler, NetworkHandlerBase, Query,
+    QueryHandler, QueryResult, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
     RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
     RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
 };

--- a/tests/mutate_neuron_activation.rs
+++ b/tests/mutate_neuron_activation.rs
@@ -40,7 +40,7 @@ fn mutate_neuron_activation_appends_event() {
         .unwrap();
     assert_eq!(mutated_id, neuron_id);
 
-    let mut store = handler.store;
+    let mut store = handler.base.store;
     let events = store.load().unwrap();
     match events.last().unwrap() {
         Event::NeuronActivationMutated(NeuronActivationMutated {
@@ -52,7 +52,7 @@ fn mutate_neuron_activation_appends_event() {
             assert_eq!(*old_activation, Activation::Identity);
             assert_ne!(*old_activation, *new_activation);
             assert_eq!(
-                handler.network.neurons.get(id).unwrap().activation,
+                handler.base.network.neurons.get(id).unwrap().activation,
                 *new_activation
             );
         }
@@ -102,7 +102,7 @@ fn mutate_neuron_activation_event_replay() {
     handler
         .handle(MutateRandomNeuronActivationCommand { exclude_io: false })
         .unwrap();
-    let store = handler.store;
+    let store = handler.base.store;
     let mut replay_store = store;
     let events = replay_store.load().unwrap();
     let net = aei_framework::DomainNetwork::hydrate(&events);

--- a/tests/mutate_synapse_weight.rs
+++ b/tests/mutate_synapse_weight.rs
@@ -62,7 +62,7 @@ fn mutate_synapse_weight_appends_event() {
         .unwrap();
     assert_eq!(mutated_id, syn_id);
 
-    let mut store = handler.store;
+    let mut store = handler.base.store;
     let events = store.load().unwrap();
     match events.last().unwrap() {
         Event::SynapseWeightMutated(SynapseWeightMutated {
@@ -74,7 +74,13 @@ fn mutate_synapse_weight_appends_event() {
             assert_eq!(*old_weight, 1.0);
             assert_ne!(*new_weight, *old_weight);
             assert_eq!(
-                handler.network.synapses.get(synapse_id).unwrap().weight,
+                handler
+                    .base
+                    .network
+                    .synapses
+                    .get(synapse_id)
+                    .unwrap()
+                    .weight,
                 *new_weight
             );
         }
@@ -111,7 +117,7 @@ fn mutate_synapse_weight_event_replay() {
         .handle(MutateRandomSynapseWeightCommand { std_dev: 0.5 })
         .unwrap();
 
-    let store = handler.store;
+    let store = handler.base.store;
     let mut replay_store = store;
     let events = replay_store.load().unwrap();
     let net = aei_framework::DomainNetwork::hydrate(&events);

--- a/tests/synapse_commands.rs
+++ b/tests/synapse_commands.rs
@@ -52,9 +52,9 @@ fn add_random_synapse_appends_event() {
     let rng = ChaCha8Rng::seed_from_u64(1);
     let mut handler = AddRandomSynapseHandler::new(store, rng).unwrap();
     let syn_id = handler.handle(AddRandomSynapseCommand).unwrap();
-    assert!(handler.network.synapses.contains_key(&syn_id));
+    assert!(handler.base.network.synapses.contains_key(&syn_id));
 
-    let mut store = handler.store;
+    let mut store = handler.base.store;
     let events = store.load().unwrap();
     match events.last().unwrap() {
         Event::RandomSynapseAdded(RandomSynapseAdded { synapse_id, .. }) => {
@@ -115,9 +115,9 @@ fn remove_random_synapse_appends_event() {
     let removed_id = handler
         .handle(RemoveRandomSynapseCommand)
         .expect("synapse removed");
-    assert!(!handler.network.synapses.contains_key(&removed_id));
+    assert!(!handler.base.network.synapses.contains_key(&removed_id));
 
-    let mut store = handler.store;
+    let mut store = handler.base.store;
     let events = store.load().unwrap();
     match events.last().unwrap() {
         Event::RandomSynapseRemoved(RandomSynapseRemoved { synapse_id }) => {
@@ -156,7 +156,7 @@ fn remove_random_synapse_event_replay() {
         .handle(RemoveRandomSynapseCommand)
         .expect("synapse removed");
 
-    let store = handler.store;
+    let store = handler.base.store;
     let mut replay_store = store;
     let events = replay_store.load().unwrap();
     let net = aei_framework::DomainNetwork::hydrate(&events);


### PR DESCRIPTION
## Summary
- add `NetworkHandlerBase` encapsulating store, network, and RNG initialization
- refactor random network handlers to embed this base
- document base in English and French glossaries

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6899ee6948e8832184a0fe888fa22e60