### PR TITLE
refactor: centralize memory handler state and pruning

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -32,6 +32,9 @@ Component that validates and executes a command, emitting one or more events. Ex
 ### NetworkHandlerBase
 Shared structure bundling an event store, a hydrated [`Network`](src/domain/network.rs), and a random number generator for command handlers operating on networks.
 
+### MemoryHandlerBase
+Shared structure bundling a memory event store and hydrated [`AdaptiveMemory`](src/domain/memory) with helpers to persist events and prune entries.
+
 ### Query Handler
 Component that serves a query by reading from a projection or read model. See [src/application/query_handler.rs](src/application/query_handler.rs).
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ handler
         score: 0.7,
     })
     .unwrap();
-let mut store = handler.store;
+let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -150,7 +150,7 @@ handler
         score: 0.7,
     })
     .unwrap();
-let mut store = handler.store;
+let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -32,6 +32,9 @@ Composant qui valide et exécute une commande, émettant un ou plusieurs événe
 ### NetworkHandlerBase
 Structure de base regroupant le magasin d'événements, le réseau hydraté et le générateur de nombres aléatoires pour les gestionnaires de commandes opérant sur les réseaux.
 
+### MemoryHandlerBase
+Structure de base regroupant le magasin d'événements mémoire et la [`AdaptiveMemory`](../../src/domain/memory) hydratée, fournissant des fonctions utilitaires pour persister les événements et élaguer les entrées.
+
 ### Gestionnaire de requête
 Composant qui sert une requête en lisant depuis une projection ou un modèle de lecture. Voir [src/application/query_handler.rs](../../src/application/query_handler.rs).
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -148,7 +148,7 @@ handler
         score: 0.7,
     })
     .unwrap();
-let mut store = handler.store;
+let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -32,7 +32,7 @@ fn main() {
         .expect("add entry");
 
     // Update the score of that entry.
-    let store = add.store;
+    let store = add.base.store;
     let mut update = UpdateMemoryScoreHandler::new(store, 10).expect("store");
     update
         .handle(UpdateMemoryScoreCommand {
@@ -42,7 +42,7 @@ fn main() {
         .expect("update score");
 
     // Build a projection and query the top entry.
-    let mut store = update.store;
+    let mut store = update.base.store;
     let events = store.load().expect("load events");
     let projection = MemoryProjection::from_events(10, &events);
     if let Some(entry) = projection.top_entries(1).first() {

--- a/src/application/memory/base.rs
+++ b/src/application/memory/base.rs
@@ -1,0 +1,77 @@
+//! Shared base for memory command handlers.
+//!
+//! Aggregates a memory event store and the hydrated [`AdaptiveMemory`].
+//! Provides helpers to persist events and prune excess entries.
+//!
+//! # Examples
+//! ```
+//! use aei_framework::application::memory::MemoryHandlerBase;
+//! use aei_framework::infrastructure::FileMemoryEventStore;
+//! use std::path::PathBuf;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let store = FileMemoryEventStore::new(PathBuf::from("memory.log"));
+//! let _base = MemoryHandlerBase::new(store, 10)?;
+//! # Ok(()) }
+//! ```
+
+use uuid::Uuid;
+
+use crate::domain::{AdaptiveMemory, MemoryEvent, MemoryPruned};
+use crate::infrastructure::MemoryEventStore;
+
+/// Maintains shared state for memory handlers.
+pub struct MemoryHandlerBase<S: MemoryEventStore> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current adaptive memory rebuilt from events.
+    pub memory: AdaptiveMemory,
+}
+
+impl<S: MemoryEventStore> MemoryHandlerBase<S> {
+    /// Loads events from the store and hydrates [`AdaptiveMemory`].
+    ///
+    /// # Arguments
+    /// * `store` - Event store containing past memory events.
+    /// * `max_size` - Maximum number of entries retained in memory.
+    ///
+    /// # Errors
+    /// Returns [`MemoryEventStore::Error`] if loading events fails.
+    pub fn new(mut store: S, max_size: usize) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let memory = AdaptiveMemory::hydrate(max_size, &events);
+        Ok(Self { store, memory })
+    }
+
+    /// Persists an event and applies it to the memory state.
+    ///
+    /// # Errors
+    /// Returns [`MemoryEventStore::Error`] if persistence fails.
+    pub fn persist(&mut self, event: &MemoryEvent) -> Result<(), S::Error> {
+        self.store.append(event)?;
+        self.memory.apply(event);
+        Ok(())
+    }
+
+    /// Prunes lowest scoring entries when capacity is exceeded.
+    ///
+    /// Returns the identifiers of removed entries.
+    ///
+    /// # Errors
+    /// Returns [`MemoryEventStore::Error`] if persisting the pruning event fails.
+    pub fn prune(&mut self) -> Result<Vec<Uuid>, S::Error> {
+        if self.memory.entries.len() <= self.memory.max_size {
+            return Ok(Vec::new());
+        }
+        let excess = self.memory.entries.len() - self.memory.max_size;
+        let mut entries = self.memory.entries.clone();
+        entries.sort_by(|a, b| a.score.partial_cmp(&b.score).unwrap());
+        let removed: Vec<Uuid> = entries.iter().take(excess).map(|e| e.id).collect();
+        let event = MemoryEvent::MemoryPruned(MemoryPruned {
+            removed_entries: removed.clone(),
+        });
+        self.store.append(&event)?;
+        self.memory.apply(&event);
+        Ok(removed)
+    }
+}

--- a/src/application/memory/mod.rs
+++ b/src/application/memory/mod.rs
@@ -1,10 +1,12 @@
 //! Application layer for adaptive memory commands and queries.
 
+pub mod base;
 pub mod commands;
 pub mod handlers;
 pub mod queries;
 pub mod query_handler;
 
+pub use base::MemoryHandlerBase;
 pub use commands::{
     AddMemoryEntryCommand, PruneMemoryCommand, RemoveMemoryEntryCommand, UpdateMemoryScoreCommand,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod domain;
 pub mod infrastructure;
 
 pub use application::memory::{
-    AddMemoryEntryCommand, AddMemoryEntryError, AddMemoryEntryHandler, MemoryQuery,
-    MemoryQueryHandler, MemoryQueryResult, PruneMemoryCommand, PruneMemoryError,
+    AddMemoryEntryCommand, AddMemoryEntryError, AddMemoryEntryHandler, MemoryHandlerBase,
+    MemoryQuery, MemoryQueryHandler, MemoryQueryResult, PruneMemoryCommand, PruneMemoryError,
     PruneMemoryHandler, RemoveMemoryEntryCommand, RemoveMemoryEntryError, RemoveMemoryEntryHandler,
     UpdateMemoryScoreCommand, UpdateMemoryScoreError, UpdateMemoryScoreHandler,
 };

--- a/tests/memory_adaptive.rs
+++ b/tests/memory_adaptive.rs
@@ -37,8 +37,8 @@ fn add_and_query_memory_entry() {
             score: 0.8,
         })
         .unwrap();
-    assert!(handler.memory.entries.iter().any(|e| e.id == id));
-    let projection = MemoryProjection::from_events(10, &handler.store.events);
+    assert!(handler.base.memory.entries.iter().any(|e| e.id == id));
+    let projection = MemoryProjection::from_events(10, &handler.base.store.events);
     let qh = MemoryQueryHandler::new(&projection);
     match qh.handle(MemoryQuery::GetEntryById { id }) {
         aei_framework::application::memory::MemoryQueryResult::Entry(Some(e)) => {
@@ -59,12 +59,12 @@ fn remove_memory_entry() {
             score: 0.2,
         })
         .unwrap();
-    let store = add.store;
+    let store = add.base.store;
     let mut remove = RemoveMemoryEntryHandler::new(store, 10).unwrap();
     remove
         .handle(RemoveMemoryEntryCommand { entry_id: id })
         .unwrap();
-    assert!(remove.memory.entries.is_empty());
+    assert!(remove.base.memory.entries.is_empty());
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn update_memory_score() {
             score: 0.2,
         })
         .unwrap();
-    let store = add.store;
+    let store = add.base.store;
     let mut update = UpdateMemoryScoreHandler::new(store, 10).unwrap();
     update
         .handle(UpdateMemoryScoreCommand {
@@ -88,6 +88,7 @@ fn update_memory_score() {
         .unwrap();
     assert_eq!(
         update
+            .base
             .memory
             .entries
             .iter()
@@ -116,8 +117,8 @@ fn prune_on_capacity_exceeded() {
             score: 0.9,
         })
         .unwrap();
-    assert_eq!(handler.memory.entries.len(), 1);
-    assert_eq!(handler.memory.entries[0].id, id2);
+    assert_eq!(handler.base.memory.entries.len(), 1);
+    assert_eq!(handler.base.memory.entries[0].id, id2);
 }
 
 #[test]
@@ -131,7 +132,7 @@ fn replay_from_event_store() {
             score: 0.5,
         })
         .unwrap();
-    let events = handler.store.events.clone();
+    let events = handler.base.store.events.clone();
     let memory = AdaptiveMemory::hydrate(10, &events);
     assert!(memory.entries.iter().any(|e| e.id == id));
 }


### PR DESCRIPTION
## Summary
- add reusable `MemoryHandlerBase` that hydrates state, persists events, and prunes excess entries
- refactor memory handlers to embed the base and invoke shared helpers
- document and test new base, updating examples and glossary

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689a0658e8cc8321b6f924b89cde5f37