### PR TITLE
Add neuron lifecycle commands and events

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -71,11 +71,23 @@ Command that creates a synapse between two randomly chosen neurons. Implemented 
 ### RemoveRandomSynapseCommand
 Command requesting the removal of a random synapse from the network. Implemented in [src/application/add_random_synapse.rs](src/application/remove_random_synapse.rs).
 
+### CreateNeuron Command
+Command that inserts a neuron with a specific identifier and activation into the network. Handled by `CommandHandler`.
+
+### RemoveNeuron Command
+Command that deletes a neuron by its identifier and prunes connected synapses. Handled by `CommandHandler`.
+
 ### MutateRandomSynapseWeightCommand
 Command that mutates the weight of a randomly selected synapse by adding Gaussian noise. Implemented in [src/application/mutate_random_synapse_weight.rs](src/application/mutate_random_synapse_weight.rs).
 
 ### SynapseWeightMutated
 Domain event recording a change in a synapse's weight. Emitted by `MutateRandomSynapseWeightHandler`.
+
+### NeuronAdded
+Domain event emitted when a neuron is added to the network. Result of `CreateNeuron`.
+
+### NeuronRemoved
+Domain event emitted when a neuron is removed from the network. Result of `RemoveNeuron`.
 
 ### Curiosity Score
 Metric representing the exploratory potential of a neuron or synapse. Recomputed via `RecalculateCuriosityScoreCommand` and stored through `CuriosityScoreUpdated` events.

--- a/docs/en/NEURON_MANAGEMENT.md
+++ b/docs/en/NEURON_MANAGEMENT.md
@@ -1,0 +1,35 @@
+# Neuron Management
+
+Explicit neuron lifecycle operations are available through the application
+layer. Two commands drive these changes:
+
+- `Command::CreateNeuron` inserts a neuron with a chosen identifier and
+  activation function.
+- `Command::RemoveNeuron` deletes a neuron by identifier and prunes all
+  attached synapses.
+
+## Examples
+
+```rust
+use aei_framework::{Activation, Command, CommandHandler, FileEventStore};
+use uuid::Uuid;
+
+fn main() {
+    let mut path = std::env::temp_dir();
+    path.push("neuron_doc.log");
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateNeuron {
+            id,
+            activation: Activation::ReLU,
+        })
+        .unwrap();
+    handler.handle(Command::RemoveNeuron { id }).unwrap();
+
+    std::fs::remove_file(path).unwrap();
+}
+```
+

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -68,11 +68,23 @@ Commande qui crée une synapse entre deux neurones choisis aléatoirement. Impl�
 ### RemoveRandomSynapseCommand
 Commande demandant la suppression d'une synapse aléatoire du réseau. Implémentée dans [src/application/remove_random_synapse.rs](../../src/application/remove_random_synapse.rs).
 
+### CreateNeuron Command
+Commande qui insère un neurone avec un identifiant et une activation spécifiques dans le réseau. Gérée par `CommandHandler`.
+
+### RemoveNeuron Command
+Commande qui supprime un neurone par son identifiant et élimine les synapses associées. Gérée par `CommandHandler`.
+
 ### MutateRandomSynapseWeightCommand
 Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoirement. Implémentée dans [src/application/mutate_random_synapse_weight.rs](../../src/application/mutate_random_synapse_weight.rs).
 
 ### SynapseWeightMutated
 Événement de domaine enregistrant la modification du poids d'une synapse. Émis par `MutateRandomSynapseWeightHandler`.
+
+### NeuronAdded
+Événement de domaine émis lorsqu'un neurone est ajouté au réseau, suite à `CreateNeuron`.
+
+### NeuronRemoved
+Événement de domaine émis lorsqu'un neurone est retiré du réseau, suite à `RemoveNeuron`.
 
 ### Activation
 Fonction non linéaire appliquée à l'entrée d'un neurone pour produire sa sortie.

--- a/docs/fr/NEURON_MANAGEMENT.md
+++ b/docs/fr/NEURON_MANAGEMENT.md
@@ -1,0 +1,35 @@
+# Gestion des neurones
+
+La couche application permet de gérer explicitement le cycle de vie des
+neurones grâce à deux commandes :
+
+- `Command::CreateNeuron` ajoute un neurone avec un identifiant et une
+  fonction d'activation choisis.
+- `Command::RemoveNeuron` supprime un neurone par identifiant et émonde
+  toutes les synapses qui y sont reliées.
+
+## Exemples
+
+```rust
+use aei_framework::{Activation, Command, CommandHandler, FileEventStore};
+use uuid::Uuid;
+
+fn main() {
+    let mut path = std::env::temp_dir();
+    path.push("neuron_doc.log");
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateNeuron {
+            id,
+            activation: Activation::ReLU,
+        })
+        .unwrap();
+    handler.handle(Command::RemoveNeuron { id }).unwrap();
+
+    std::fs::remove_file(path).unwrap();
+}
+```
+

--- a/src/application/command_handler.rs
+++ b/src/application/command_handler.rs
@@ -1,7 +1,7 @@
 //! Handles write-side commands and persists resulting events.
 
 use crate::application::Command;
-use crate::domain::{Event, Network};
+use crate::domain::{Event, Network, NeuronAdded, NeuronRemoved};
 use crate::infrastructure::EventStore;
 
 /// Processes commands, emitting events and updating the in-memory state.
@@ -23,6 +23,15 @@ impl<S: EventStore> CommandHandler<S> {
     /// Handles a command by converting it to an event and applying it.
     pub fn handle(&mut self, command: Command) -> Result<(), S::Error> {
         let event = match command {
+            Command::CreateNeuron { id, activation } => {
+                Event::NeuronAdded(NeuronAdded {
+                    neuron_id: id,
+                    activation,
+                })
+            }
+            Command::RemoveNeuron { id } => {
+                Event::NeuronRemoved(NeuronRemoved { neuron_id: id })
+            }
             Command::CreateSynapse {
                 id,
                 from,

--- a/src/application/command_handler.rs
+++ b/src/application/command_handler.rs
@@ -23,15 +23,11 @@ impl<S: EventStore> CommandHandler<S> {
     /// Handles a command by converting it to an event and applying it.
     pub fn handle(&mut self, command: Command) -> Result<(), S::Error> {
         let event = match command {
-            Command::CreateNeuron { id, activation } => {
-                Event::NeuronAdded(NeuronAdded {
-                    neuron_id: id,
-                    activation,
-                })
-            }
-            Command::RemoveNeuron { id } => {
-                Event::NeuronRemoved(NeuronRemoved { neuron_id: id })
-            }
+            Command::CreateNeuron { id, activation } => Event::NeuronAdded(NeuronAdded {
+                neuron_id: id,
+                activation,
+            }),
+            Command::RemoveNeuron { id } => Event::NeuronRemoved(NeuronRemoved { neuron_id: id }),
             Command::CreateSynapse {
                 id,
                 from,

--- a/src/application/commands.rs
+++ b/src/application/commands.rs
@@ -1,10 +1,23 @@
 //! Commands describing intent to change the domain state.
 
+use crate::domain::Activation;
 use uuid::Uuid;
 
 /// Write-side operations handled by the [`CommandHandler`].
 #[derive(Debug, Clone)]
 pub enum Command {
+    /// Create a neuron with the specified identifier and activation.
+    CreateNeuron {
+        /// Identifier of the neuron to create.
+        id: Uuid,
+        /// Activation function assigned to the neuron.
+        activation: Activation,
+    },
+    /// Remove a neuron by its identifier.
+    RemoveNeuron {
+        /// Identifier of the neuron to remove.
+        id: Uuid,
+    },
     /// Create a synapse between two existing neurons.
     CreateSynapse {
         id: Uuid,

--- a/src/application/recalculate_curiosity_score.rs
+++ b/src/application/recalculate_curiosity_score.rs
@@ -96,6 +96,8 @@ impl<S: EventStore> RecalculateCuriosityScoreHandler<S> {
         match event {
             Event::RandomNeuronAdded(e) => e.neuron_id == id,
             Event::RandomNeuronRemoved(e) => e.neuron_id == id,
+            Event::NeuronAdded(e) => e.neuron_id == id,
+            Event::NeuronRemoved(e) => e.neuron_id == id,
             Event::SynapseCreated {
                 id: sid, from, to, ..
             } => *sid == id || *from == id || *to == id,

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -14,6 +14,10 @@ pub enum Event {
     RandomNeuronAdded(RandomNeuronAdded),
     /// A neuron was removed from the network.
     RandomNeuronRemoved(RandomNeuronRemoved),
+    /// A neuron was explicitly added to the network.
+    NeuronAdded(NeuronAdded),
+    /// A neuron was explicitly removed from the network.
+    NeuronRemoved(NeuronRemoved),
     /// A synapse connecting two neurons was created.
     SynapseCreated {
         id: Uuid,
@@ -47,6 +51,44 @@ pub struct RandomNeuronAdded {
 /// Event emitted when a random neuron is removed from the network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RandomNeuronRemoved {
+    /// Identifier of the removed neuron.
+    pub neuron_id: Uuid,
+}
+
+/// Event emitted when a neuron is added to the network.
+///
+/// # Examples
+///
+/// ```
+/// use aei_framework::{Activation, Event, NeuronAdded};
+/// use uuid::Uuid;
+///
+/// let id = Uuid::new_v4();
+/// let event = Event::NeuronAdded(NeuronAdded { neuron_id: id, activation: Activation::ReLU });
+/// # let _ = event;
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeuronAdded {
+    /// Identifier of the created neuron.
+    pub neuron_id: Uuid,
+    /// Activation assigned to the neuron.
+    pub activation: Activation,
+}
+
+/// Event emitted when a neuron is removed from the network.
+///
+/// # Examples
+///
+/// ```
+/// use aei_framework::{Event, NeuronRemoved};
+/// use uuid::Uuid;
+///
+/// let id = Uuid::new_v4();
+/// let event = Event::NeuronRemoved(NeuronRemoved { neuron_id: id });
+/// # let _ = event;
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeuronRemoved {
     /// Identifier of the removed neuron.
     pub neuron_id: Uuid,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -9,8 +9,9 @@ mod synapse;
 
 pub use activation::Activation;
 pub use events::{
-    CuriosityScoreUpdated, Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved,
-    RandomSynapseAdded, RandomSynapseRemoved, SynapseWeightMutated,
+    CuriosityScoreUpdated, Event, NeuronActivationMutated, NeuronAdded, NeuronRemoved,
+    RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+    SynapseWeightMutated,
 };
 pub use memory::{
     AdaptiveMemory, MemoryEntry, MemoryEntryAdded, MemoryEntryRemoved, MemoryEvent, MemoryPruned,

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -6,8 +6,9 @@
 use std::collections::HashMap;
 
 use super::events::{
-    CuriosityScoreUpdated, Event, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved,
-    RandomSynapseAdded, RandomSynapseRemoved, SynapseWeightMutated,
+    CuriosityScoreUpdated, Event, NeuronActivationMutated, NeuronAdded, NeuronRemoved,
+    RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
+    SynapseWeightMutated,
 };
 use super::{Neuron, Synapse};
 use uuid::Uuid;
@@ -40,6 +41,12 @@ impl Network {
             }
             Event::RandomNeuronRemoved(e) => {
                 self.apply_random_neuron_removed(e);
+            }
+            Event::NeuronAdded(e) => {
+                self.apply_neuron_added(e);
+            }
+            Event::NeuronRemoved(e) => {
+                self.apply_neuron_removed(e);
             }
             Event::SynapseCreated {
                 id,
@@ -83,6 +90,19 @@ impl Network {
 
     /// Applies a [`RandomNeuronRemoved`] event to the network state.
     fn apply_random_neuron_removed(&mut self, event: &RandomNeuronRemoved) {
+        self.neurons.remove(&event.neuron_id);
+        self.synapses
+            .retain(|_, s| s.from != event.neuron_id && s.to != event.neuron_id);
+    }
+
+    /// Applies a [`NeuronAdded`] event to the network state.
+    fn apply_neuron_added(&mut self, event: &NeuronAdded) {
+        self.neurons
+            .insert(event.neuron_id, Neuron::with_id(event.neuron_id, event.activation));
+    }
+
+    /// Applies a [`NeuronRemoved`] event to the network state.
+    fn apply_neuron_removed(&mut self, event: &NeuronRemoved) {
         self.neurons.remove(&event.neuron_id);
         self.synapses
             .retain(|_, s| s.from != event.neuron_id && s.to != event.neuron_id);

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -97,8 +97,10 @@ impl Network {
 
     /// Applies a [`NeuronAdded`] event to the network state.
     fn apply_neuron_added(&mut self, event: &NeuronAdded) {
-        self.neurons
-            .insert(event.neuron_id, Neuron::with_id(event.neuron_id, event.activation));
+        self.neurons.insert(
+            event.neuron_id,
+            Neuron::with_id(event.neuron_id, event.activation),
+        );
     }
 
     /// Applies a [`NeuronRemoved`] event to the network state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub use application::{
 pub use domain::{
     Activation, AdaptiveMemory, CuriosityScoreUpdated, Event, MemoryEntry, MemoryEntryAdded,
     MemoryEntryRemoved, MemoryEvent, MemoryPruned, MemoryScoreUpdated, Network as DomainNetwork,
-    Neuron, NeuronActivationMutated, RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded,
-    RandomSynapseRemoved, Synapse, SynapseWeightMutated,
+    Neuron, NeuronActivationMutated, NeuronAdded, NeuronRemoved, RandomNeuronAdded,
+    RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved, Synapse, SynapseWeightMutated,
 };
 pub use infrastructure::{
     EventStore, FileEventStore, FileMemoryEventStore, JsonlEventStore, MemoryEventStore,

--- a/tests/neuron_lifecycle.rs
+++ b/tests/neuron_lifecycle.rs
@@ -67,9 +67,7 @@ fn remove_neuron_removes_synapses() {
         .unwrap();
     assert!(handler.network.synapses.contains_key(&syn_id));
 
-    handler
-        .handle(Command::RemoveNeuron { id: id1 })
-        .unwrap();
+    handler.handle(Command::RemoveNeuron { id: id1 }).unwrap();
     assert!(!handler.network.neurons.contains_key(&id1));
     assert!(handler.network.synapses.is_empty());
 
@@ -94,13 +92,10 @@ fn event_replay_reconstructs_state() {
             activation: Activation::Identity,
         })
         .unwrap();
-    handler
-        .handle(Command::RemoveNeuron { id })
-        .unwrap();
+    handler.handle(Command::RemoveNeuron { id }).unwrap();
 
     let mut reader = FileEventStore::new(path);
     let events = reader.load().unwrap();
     let net = DomainNetwork::hydrate(&events);
     assert!(!net.neurons.contains_key(&id));
 }
-

--- a/tests/neuron_lifecycle.rs
+++ b/tests/neuron_lifecycle.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    Activation, Command, CommandHandler, DomainNetwork, Event, FileEventStore, NeuronAdded,
+    NeuronRemoved,
+};
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_neuron_lifecycle_{}.log", Uuid::new_v4()));
+    path
+}
+
+#[test]
+fn create_neuron_appends_event() {
+    let path = temp_path();
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateNeuron {
+            id,
+            activation: Activation::Identity,
+        })
+        .unwrap();
+    assert!(handler.network.neurons.contains_key(&id));
+
+    let mut store = FileEventStore::new(path);
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::NeuronAdded(NeuronAdded { neuron_id, .. }) => assert_eq!(*neuron_id, id),
+        e => panic!("unexpected event {e:?}"),
+    }
+}
+
+#[test]
+fn remove_neuron_removes_synapses() {
+    let path = temp_path();
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let id1 = Uuid::new_v4();
+    let id2 = Uuid::new_v4();
+    handler
+        .handle(Command::CreateNeuron {
+            id: id1,
+            activation: Activation::Identity,
+        })
+        .unwrap();
+    handler
+        .handle(Command::CreateNeuron {
+            id: id2,
+            activation: Activation::Identity,
+        })
+        .unwrap();
+
+    let syn_id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateSynapse {
+            id: syn_id,
+            from: id1,
+            to: id2,
+            weight: 1.0,
+        })
+        .unwrap();
+    assert!(handler.network.synapses.contains_key(&syn_id));
+
+    handler
+        .handle(Command::RemoveNeuron { id: id1 })
+        .unwrap();
+    assert!(!handler.network.neurons.contains_key(&id1));
+    assert!(handler.network.synapses.is_empty());
+
+    let mut store = FileEventStore::new(path);
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::NeuronRemoved(NeuronRemoved { neuron_id }) => assert_eq!(*neuron_id, id1),
+        e => panic!("unexpected event {e:?}"),
+    }
+}
+
+#[test]
+fn event_replay_reconstructs_state() {
+    let path = temp_path();
+    let store = FileEventStore::new(path.clone());
+    let mut handler = CommandHandler::new(store).unwrap();
+
+    let id = Uuid::new_v4();
+    handler
+        .handle(Command::CreateNeuron {
+            id,
+            activation: Activation::Identity,
+        })
+        .unwrap();
+    handler
+        .handle(Command::RemoveNeuron { id })
+        .unwrap();
+
+    let mut reader = FileEventStore::new(path);
+    let events = reader.load().unwrap();
+    let net = DomainNetwork::hydrate(&events);
+    assert!(!net.neurons.contains_key(&id));
+}
+


### PR DESCRIPTION
## Summary
- add `NeuronAdded` and `NeuronRemoved` domain events with network support
- extend application commands and handler for creating and removing neurons
- document neuron lifecycle API and update bilingual glossary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b16258f4083219697ef698c0a0af2