### PR TITLE
feat: add explicit synapse weight setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adaptive memory module with event-sourced commands, projection and queries.
 - Random neuron activation mutation through `MutateRandomNeuronActivationCommand` and `MutateRandomNeuronActivationHandler`.
 - Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
+- Explicit synapse weight updates via `SetSynapseWeightCommand` and `SetSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`
 - Activation function derivatives enabling gradient descent

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -83,6 +83,12 @@ Command that mutates the weight of a randomly selected synapse by adding Gaussia
 ### SynapseWeightMutated
 Domain event recording a change in a synapse's weight. Emitted by `MutateRandomSynapseWeightHandler`.
 
+### SetSynapseWeightCommand
+Command that assigns a specific weight to an existing synapse. Implemented in [src/application/set_synapse_weight.rs](src/application/set_synapse_weight.rs).
+
+### SynapseWeightSet
+Domain event recording an explicit update of a synapse's weight. Emitted by `SetSynapseWeightHandler`.
+
 ### NeuronAdded
 Domain event emitted when a neuron is added to the network. Result of `CreateNeuron`.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
 }
 ```
 
+## Set Synapse Weight
+
+Assign a precise weight to an existing synapse:
+
+```rust
+use aei_framework::{SetSynapseWeightCommand, SetSynapseWeightHandler, FileEventStore};
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = SetSynapseWeightHandler::new(store).unwrap();
+let synapse_id = uuid::Uuid::new_v4(); // existing synapse identifier
+handler
+    .handle(SetSynapseWeightCommand { synapse_id, new_weight: 0.5 })
+    .unwrap();
+```
+
 ## Random Synapse Weight Mutation
 
 Adjust a synapse's weight by adding Gaussian noise:

--- a/docs/en/CHANGELOG.md
+++ b/docs/en/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adaptive memory module with event-sourced commands, projection and queries.
 - Random neuron activation mutation through `MutateRandomNeuronActivationCommand` and `MutateRandomNeuronActivationHandler`.
 - Random synapse weight mutation through `MutateRandomSynapseWeightCommand` and `MutateRandomSynapseWeightHandler`.
+- Explicit synapse weight updates via `SetSynapseWeightCommand` and `SetSynapseWeightHandler`.
 - Event-driven example and synapse command tests.
 - Backpropagation training with `Network::train` and `Network::predict`
 - Activation function derivatives enabling gradient descent

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -107,6 +107,22 @@ if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
 }
 ```
 
+## Set Synapse Weight
+
+Assign a precise weight to an existing synapse:
+
+```rust
+use aei_framework::{SetSynapseWeightCommand, SetSynapseWeightHandler, FileEventStore};
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = SetSynapseWeightHandler::new(store).unwrap();
+let synapse_id = uuid::Uuid::new_v4(); // existing synapse identifier
+handler
+    .handle(SetSynapseWeightCommand { synapse_id, new_weight: 0.5 })
+    .unwrap();
+```
+
 ## Random Synapse Weight Mutation
 
 Mutate an existing synapse by adding Gaussian noise to its weight:

--- a/docs/fr/CHANGELOG.md
+++ b/docs/fr/CHANGELOG.md
@@ -10,6 +10,7 @@ et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Module de mémoire adaptative avec commandes événementielles, projection et requêtes.
 - Mutation aléatoire de l’activation des neurones via `MutateRandomNeuronActivationCommand` et `MutateRandomNeuronActivationHandler`.
 - Mutation aléatoire du poids des synapses via `MutateRandomSynapseWeightCommand` et `MutateRandomSynapseWeightHandler`.
+- Mise à jour explicite du poids d'une synapse via `SetSynapseWeightCommand` et `SetSynapseWeightHandler`.
 - Exemple orienté événements et tests de commande de synapse.
 - Entraînement par rétropropagation avec `Network::train` et `Network::predict`
 - Dérivées des fonctions d'activation permettant la descente de gradient

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -80,6 +80,12 @@ Commande qui applique un bruit gaussien au poids d'une synapse choisie aléatoir
 ### SynapseWeightMutated
 Événement de domaine enregistrant la modification du poids d'une synapse. Émis par `MutateRandomSynapseWeightHandler`.
 
+### SetSynapseWeightCommand
+Commande qui assigne un poids spécifique à une synapse existante. Implémentée dans [src/application/set_synapse_weight.rs](../../src/application/set_synapse_weight.rs).
+
+### SynapseWeightSet
+Événement de domaine enregistrant la mise à jour explicite du poids d'une synapse. Émis par `SetSynapseWeightHandler`.
+
 ### NeuronAdded
 Événement de domaine émis lorsqu'un neurone est ajouté au réseau, suite à `CreateNeuron`.
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -105,6 +105,22 @@ if let Ok(removed_id) = handler.handle(RemoveRandomSynapseCommand) {
 }
 ```
 
+## Définir le poids d'une synapse
+
+Assignez un poids précis à une synapse existante :
+
+```rust
+use aei_framework::{SetSynapseWeightCommand, SetSynapseWeightHandler, FileEventStore};
+use std::path::PathBuf;
+
+let store = FileEventStore::new(PathBuf::from("events.log"));
+let mut handler = SetSynapseWeightHandler::new(store).unwrap();
+let synapse_id = uuid::Uuid::new_v4(); // identifiant d'une synapse existante
+handler
+    .handle(SetSynapseWeightCommand { synapse_id, new_weight: 0.5 })
+    .unwrap();
+```
+
 ## Mutation aléatoire du poids d'une synapse
 
 Ajustez le poids d'une synapse en ajoutant un bruit gaussien :

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -13,6 +13,7 @@ mod query_handler;
 mod recalculate_curiosity_score;
 mod remove_random_neuron;
 mod remove_random_synapse;
+mod set_synapse_weight;
 
 pub use add_random_neuron::{AddRandomNeuronCommand, AddRandomNeuronError, AddRandomNeuronHandler};
 pub use add_random_synapse::{
@@ -39,4 +40,7 @@ pub use remove_random_neuron::{
 };
 pub use remove_random_synapse::{
     RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
+};
+pub use set_synapse_weight::{
+    SetSynapseWeightCommand, SetSynapseWeightError, SetSynapseWeightHandler,
 };

--- a/src/application/recalculate_curiosity_score.rs
+++ b/src/application/recalculate_curiosity_score.rs
@@ -105,6 +105,7 @@ impl<S: EventStore> RecalculateCuriosityScoreHandler<S> {
             Event::RandomSynapseAdded(e) => e.synapse_id == id || e.from == id || e.to == id,
             Event::RandomSynapseRemoved(e) => e.synapse_id == id,
             Event::SynapseWeightMutated(e) => e.synapse_id == id,
+            Event::SynapseWeightSet(e) => e.synapse_id == id,
             Event::NeuronActivationMutated(e) => e.neuron_id == id,
             Event::CuriosityScoreUpdated(e) => e.target_id == id,
         }

--- a/src/application/set_synapse_weight.rs
+++ b/src/application/set_synapse_weight.rs
@@ -1,0 +1,135 @@
+//! Command and handler for explicitly setting a synapse's weight.
+//!
+//! This operation emits a [`SynapseWeightSet`](crate::domain::SynapseWeightSet)
+//! event, which is persisted and applied to the [`Network`](crate::domain::Network).
+
+use crate::domain::{Event, Network, SynapseWeightSet};
+use crate::infrastructure::EventStore;
+use uuid::Uuid;
+
+/// Command requesting to assign a new weight to a synapse.
+#[derive(Debug, Clone)]
+pub struct SetSynapseWeightCommand {
+    /// Identifier of the synapse to update.
+    pub synapse_id: Uuid,
+    /// Desired weight value.
+    pub new_weight: f64,
+}
+
+/// Errors that may occur while setting a synapse's weight.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SetSynapseWeightError {
+    /// The specified synapse does not exist in the network.
+    SynapseNotFound,
+    /// Persisting the event failed.
+    StorageError,
+}
+
+/// Handles [`SetSynapseWeightCommand`] and applies the resulting event.
+pub struct SetSynapseWeightHandler<S: EventStore> {
+    /// Event store used for persistence.
+    pub store: S,
+    /// Current network state reconstructed from events.
+    pub network: Network,
+}
+
+impl<S: EventStore> SetSynapseWeightHandler<S> {
+    /// Loads events from the store to initialize the handler.
+    pub fn new(mut store: S) -> Result<Self, S::Error> {
+        let events = store.load()?;
+        let network = Network::hydrate(&events);
+        Ok(Self { store, network })
+    }
+
+    /// Handles the command by emitting and applying a [`SynapseWeightSet`] event.
+    ///
+    /// # Errors
+    /// Returns [`SetSynapseWeightError::SynapseNotFound`] if the target synapse is
+    /// missing, or [`SetSynapseWeightError::StorageError`] if persisting the event
+    /// fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use aei_framework::{SetSynapseWeightCommand, SetSynapseWeightHandler, FileEventStore};
+    /// use uuid::Uuid;
+    /// use std::path::PathBuf;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = FileEventStore::new(PathBuf::from("events.log"));
+    /// let mut handler = SetSynapseWeightHandler::new(store)?;
+    /// let synapse_id = Uuid::new_v4();
+    /// // network must already contain `synapse_id`
+    /// let _ = handler.handle(SetSynapseWeightCommand { synapse_id, new_weight: 0.5 });
+    /// # Ok(()) }
+    /// ```
+    pub fn handle(&mut self, cmd: SetSynapseWeightCommand) -> Result<(), SetSynapseWeightError> {
+        let old_weight = self
+            .network
+            .synapses
+            .get(&cmd.synapse_id)
+            .map(|s| s.weight)
+            .ok_or(SetSynapseWeightError::SynapseNotFound)?;
+        let event = Event::SynapseWeightSet(SynapseWeightSet {
+            synapse_id: cmd.synapse_id,
+            old_weight,
+            new_weight: cmd.new_weight,
+        });
+        self.store
+            .append(&event)
+            .map_err(|_| SetSynapseWeightError::StorageError)?;
+        self.network.apply(&event);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{RandomNeuronAdded, RandomSynapseAdded};
+    use crate::infrastructure::FileEventStore;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn temp_path() -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("set_weight_{}.log", Uuid::new_v4()));
+        path
+    }
+
+    #[test]
+    fn set_synapse_weight_updates_network() {
+        let path = temp_path();
+        let mut store = FileEventStore::new(path.clone());
+        let n1 = Uuid::new_v4();
+        let n2 = Uuid::new_v4();
+        let syn_id = Uuid::new_v4();
+        let events = [
+            Event::RandomNeuronAdded(RandomNeuronAdded {
+                neuron_id: n1,
+                activation: crate::domain::Activation::Identity,
+            }),
+            Event::RandomNeuronAdded(RandomNeuronAdded {
+                neuron_id: n2,
+                activation: crate::domain::Activation::Identity,
+            }),
+            Event::RandomSynapseAdded(RandomSynapseAdded {
+                synapse_id: syn_id,
+                from: n1,
+                to: n2,
+                weight: 1.0,
+            }),
+        ];
+        for e in &events {
+            store.append(e).unwrap();
+        }
+
+        let mut handler = SetSynapseWeightHandler::new(FileEventStore::new(path)).unwrap();
+        handler
+            .handle(SetSynapseWeightCommand {
+                synapse_id: syn_id,
+                new_weight: 2.0,
+            })
+            .unwrap();
+        assert_eq!(handler.network.synapses.get(&syn_id).unwrap().weight, 2.0);
+    }
+}

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -33,6 +33,8 @@ pub enum Event {
     RandomSynapseRemoved(RandomSynapseRemoved),
     /// The weight of an existing synapse was mutated.
     SynapseWeightMutated(SynapseWeightMutated),
+    /// The weight of an existing synapse was explicitly set.
+    SynapseWeightSet(SynapseWeightSet),
     /// The activation function of a neuron was mutated.
     NeuronActivationMutated(NeuronActivationMutated),
     /// The curiosity score of a neuron or synapse was updated.
@@ -121,6 +123,32 @@ pub struct SynapseWeightMutated {
     /// Previous weight of the synapse before mutation.
     pub old_weight: f64,
     /// Newly assigned weight after mutation.
+    pub new_weight: f64,
+}
+
+/// Event emitted when the weight of a synapse is set explicitly.
+///
+/// # Examples
+///
+/// ```
+/// use aei_framework::{Event, SynapseWeightSet};
+/// use uuid::Uuid;
+///
+/// let id = Uuid::new_v4();
+/// let event = Event::SynapseWeightSet(SynapseWeightSet {
+///     synapse_id: id,
+///     old_weight: 0.2,
+///     new_weight: 0.5,
+/// });
+/// # let _ = event;
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SynapseWeightSet {
+    /// Identifier of the updated synapse.
+    pub synapse_id: Uuid,
+    /// Previous weight of the synapse before the update.
+    pub old_weight: f64,
+    /// New weight assigned to the synapse.
     pub new_weight: f64,
 }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -11,7 +11,7 @@ pub use activation::Activation;
 pub use events::{
     CuriosityScoreUpdated, Event, NeuronActivationMutated, NeuronAdded, NeuronRemoved,
     RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
-    SynapseWeightMutated,
+    SynapseWeightMutated, SynapseWeightSet,
 };
 pub use memory::{
     AdaptiveMemory, MemoryEntry, MemoryEntryAdded, MemoryEntryRemoved, MemoryEvent, MemoryPruned,

--- a/src/domain/network.rs
+++ b/src/domain/network.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use super::events::{
     CuriosityScoreUpdated, Event, NeuronActivationMutated, NeuronAdded, NeuronRemoved,
     RandomNeuronAdded, RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved,
-    SynapseWeightMutated,
+    SynapseWeightMutated, SynapseWeightSet,
 };
 use super::{Neuron, Synapse};
 use uuid::Uuid;
@@ -70,6 +70,9 @@ impl Network {
             }
             Event::SynapseWeightMutated(e) => {
                 self.apply_synapse_weight_mutated(e);
+            }
+            Event::SynapseWeightSet(e) => {
+                self.apply_synapse_weight_set(e);
             }
             Event::NeuronActivationMutated(e) => {
                 self.apply_neuron_activation_mutated(e);
@@ -134,6 +137,13 @@ impl Network {
 
     /// Applies a [`SynapseWeightMutated`] event to the network state.
     fn apply_synapse_weight_mutated(&mut self, event: &SynapseWeightMutated) {
+        if let Some(synapse) = self.synapses.get_mut(&event.synapse_id) {
+            synapse.weight = event.new_weight;
+        }
+    }
+
+    /// Applies a [`SynapseWeightSet`] event to the network state.
+    fn apply_synapse_weight_set(&mut self, event: &SynapseWeightSet) {
         if let Some(synapse) = self.synapses.get_mut(&event.synapse_id) {
             synapse.weight = event.new_weight;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,14 @@ pub use application::{
     QueryHandler, QueryResult, RecalculateCuriosityScoreCommand, RecalculateCuriosityScoreHandler,
     RemoveRandomNeuronCommand, RemoveRandomNeuronError, RemoveRandomNeuronHandler,
     RemoveRandomSynapseCommand, RemoveRandomSynapseError, RemoveRandomSynapseHandler,
+    SetSynapseWeightCommand, SetSynapseWeightError, SetSynapseWeightHandler,
 };
 pub use domain::{
     Activation, AdaptiveMemory, CuriosityScoreUpdated, Event, MemoryEntry, MemoryEntryAdded,
     MemoryEntryRemoved, MemoryEvent, MemoryPruned, MemoryScoreUpdated, Network as DomainNetwork,
     Neuron, NeuronActivationMutated, NeuronAdded, NeuronRemoved, RandomNeuronAdded,
     RandomNeuronRemoved, RandomSynapseAdded, RandomSynapseRemoved, Synapse, SynapseWeightMutated,
+    SynapseWeightSet,
 };
 pub use infrastructure::{
     EventStore, FileEventStore, FileMemoryEventStore, JsonlEventStore, MemoryEventStore,

--- a/tests/set_synapse_weight.rs
+++ b/tests/set_synapse_weight.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use aei_framework::{
+    application::{Query, QueryHandler, QueryResult},
+    domain::{Event, RandomNeuronAdded, RandomSynapseAdded, SynapseWeightSet},
+    infrastructure::{projection::NetworkProjection, FileEventStore},
+    Activation, SetSynapseWeightCommand, SetSynapseWeightHandler,
+};
+use uuid::Uuid;
+
+fn temp_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("aei_set_weight_{}.log", Uuid::new_v4()));
+    path
+}
+
+fn seed_network(store: &mut FileEventStore, n1: Uuid, n2: Uuid, syn: Uuid) {
+    let events = [
+        Event::RandomNeuronAdded(RandomNeuronAdded {
+            neuron_id: n1,
+            activation: Activation::Identity,
+        }),
+        Event::RandomNeuronAdded(RandomNeuronAdded {
+            neuron_id: n2,
+            activation: Activation::Identity,
+        }),
+        Event::RandomSynapseAdded(RandomSynapseAdded {
+            synapse_id: syn,
+            from: n1,
+            to: n2,
+            weight: 1.0,
+        }),
+    ];
+    for e in &events {
+        store.append(e).unwrap();
+    }
+}
+
+#[test]
+fn set_synapse_weight_appends_event() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    let syn_id = Uuid::new_v4();
+    seed_network(&mut store, n1, n2, syn_id);
+
+    let mut handler = SetSynapseWeightHandler::new(FileEventStore::new(path.clone())).unwrap();
+    handler
+        .handle(SetSynapseWeightCommand {
+            synapse_id: syn_id,
+            new_weight: 2.0,
+        })
+        .unwrap();
+
+    let mut store = handler.store;
+    let events = store.load().unwrap();
+    match events.last().unwrap() {
+        Event::SynapseWeightSet(SynapseWeightSet {
+            synapse_id,
+            new_weight,
+            ..
+        }) => {
+            assert_eq!(*synapse_id, syn_id);
+            assert_eq!(*new_weight, 2.0);
+            assert_eq!(
+                handler.network.synapses.get(synapse_id).unwrap().weight,
+                *new_weight
+            );
+        }
+        e => panic!("unexpected event {e:?}"),
+    }
+}
+
+#[test]
+fn set_synapse_weight_event_replay() {
+    let path = temp_path();
+    let mut store = FileEventStore::new(path.clone());
+    let n1 = Uuid::new_v4();
+    let n2 = Uuid::new_v4();
+    let syn_id = Uuid::new_v4();
+    seed_network(&mut store, n1, n2, syn_id);
+
+    let mut handler = SetSynapseWeightHandler::new(FileEventStore::new(path.clone())).unwrap();
+    handler
+        .handle(SetSynapseWeightCommand {
+            synapse_id: syn_id,
+            new_weight: 2.0,
+        })
+        .unwrap();
+
+    let events = handler.store.load().unwrap();
+    let net = aei_framework::DomainNetwork::hydrate(&events);
+    assert_eq!(net.synapses.get(&syn_id).unwrap().weight, 2.0);
+
+    let projection = NetworkProjection::from_events(&events);
+    let handler = QueryHandler::new(&projection);
+    match handler.handle(Query::GetSynapse { id: syn_id }) {
+        QueryResult::Synapse(Some(s)) => assert_eq!(s.weight, 2.0),
+        _ => panic!("synapse not found"),
+    }
+}


### PR DESCRIPTION
## Summary
- allow setting synapse weights with a dedicated command and handler
- emit and apply `SynapseWeightSet` events to networks
- document and test explicit synapse weight updates

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b25b0d68c8321b63990e9b49d5fad