### PR TITLE
feat: add curiosity score query

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -97,3 +97,9 @@ Domain event emitted when a neuron is removed from the network. Result of `Remov
 
 ### Curiosity Score
 Metric representing the exploratory potential of a neuron or synapse. Recomputed via `RecalculateCuriosityScoreCommand` and stored through `CuriosityScoreUpdated` events.
+
+### CuriosityScoreProjection
+Read model mapping identifiers to curiosity scores. See [src/infrastructure/projection/curiosity.rs](src/infrastructure/projection/curiosity.rs).
+
+### GetCuriosityScore Query
+Query retrieving a curiosity score for a neuron or synapse via [`QueryHandler`](src/application/query_handler.rs).

--- a/docs/en/CURIOSITY_SCORE.md
+++ b/docs/en/CURIOSITY_SCORE.md
@@ -5,3 +5,29 @@ The *Curiosity Score* measures how novel or promising a neuron or synapse is dur
 ## Recalculation
 
 Use `RecalculateCuriosityScoreCommand` to recompute the score for specific identifiers or for the entire network. A `CuriosityScoreUpdated` event is emitted for each updated element.
+
+## Retrieval
+
+After scores are updated, they can be queried using [`Query::GetCuriosityScore`](../../src/application/queries.rs) and the [`QueryHandler`](../../src/application/query_handler.rs) with a `CuriosityScoreProjection`.
+
+```rust
+use aei_framework::{
+    application::{Query, QueryHandler, QueryResult},
+    domain::{Activation, CuriosityScoreUpdated, Event, RandomNeuronAdded},
+    infrastructure::projection::{CuriosityScoreProjection, NetworkProjection},
+};
+use uuid::Uuid;
+
+let id = Uuid::new_v4();
+let events = vec![
+    Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation: Activation::ReLU }),
+    Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id: id, old_score: 0.0, new_score: 0.8 }),
+];
+let network = NetworkProjection::from_events(&events);
+let curiosity = CuriosityScoreProjection::from_events(&events);
+let handler = QueryHandler::new(&network).with_curiosity_projection(&curiosity);
+
+if let QueryResult::CuriosityScore(Some(score)) = handler.handle(Query::GetCuriosityScore { id }) {
+    assert_eq!(score, 0.8);
+}
+```

--- a/docs/fr/CURIOSITY_SCORE.md
+++ b/docs/fr/CURIOSITY_SCORE.md
@@ -5,3 +5,29 @@ Le *Score de Curiosité* mesure le caractère novateur ou prometteur d'un neuron
 ## Recalcul
 
 Utilisez `RecalculateCuriosityScoreCommand` pour recalculer le score pour des identifiants spécifiques ou pour l'ensemble du réseau. Un événement `CuriosityScoreUpdated` est émis pour chaque élément mis à jour.
+
+## Récupération
+
+Après mise à jour des scores, ils peuvent être interrogés via [`Query::GetCuriosityScore`](../../src/application/queries.rs) et [`QueryHandler`](../../src/application/query_handler.rs) avec une `CuriosityScoreProjection`.
+
+```rust
+use aei_framework::{
+    application::{Query, QueryHandler, QueryResult},
+    domain::{Activation, CuriosityScoreUpdated, Event, RandomNeuronAdded},
+    infrastructure::projection::{CuriosityScoreProjection, NetworkProjection},
+};
+use uuid::Uuid;
+
+let id = Uuid::new_v4();
+let events = vec![
+    Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation: Activation::ReLU }),
+    Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id: id, old_score: 0.0, new_score: 0.8 }),
+];
+let network = NetworkProjection::from_events(&events);
+let curiosity = CuriosityScoreProjection::from_events(&events);
+let handler = QueryHandler::new(&network).with_curiosity_projection(&curiosity);
+
+if let QueryResult::CuriosityScore(Some(score)) = handler.handle(Query::GetCuriosityScore { id }) {
+    assert_eq!(score, 0.8);
+}
+```

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -97,3 +97,9 @@ Fonction non linéaire appliquée à l'entrée d'un neurone pour produire sa sor
 
 ### Score de curiosité
 Métrique représentant le potentiel exploratoire d'un neurone ou d'une synapse. Recalculé via `RecalculateCuriosityScoreCommand` et persisté par des événements `CuriosityScoreUpdated`.
+
+### Projection du score de curiosité
+Modèle de lecture associant des identifiants aux scores de curiosité. Voir [src/infrastructure/projection/curiosity.rs](../../src/infrastructure/projection/curiosity.rs).
+
+### Requête GetCuriosityScore
+Requête récupérant le score de curiosité d'un neurone ou d'une synapse via [`QueryHandler`](../../src/application/query_handler.rs).

--- a/src/application/queries.rs
+++ b/src/application/queries.rs
@@ -15,4 +15,6 @@ pub enum Query {
     GetSynapse { id: Uuid },
     /// Fetch the activation function of a neuron by identifier.
     GetNeuronActivation { id: Uuid },
+    /// Fetch the curiosity score for a neuron or synapse by identifier.
+    GetCuriosityScore { id: Uuid },
 }

--- a/src/application/query_handler.rs
+++ b/src/application/query_handler.rs
@@ -2,7 +2,7 @@
 
 use crate::application::Query;
 use crate::domain::{Activation, Neuron, Synapse};
-use crate::infrastructure::projection::NetworkProjection;
+use crate::infrastructure::projection::{CuriosityScoreProjection, NetworkProjection};
 use uuid::Uuid;
 
 /// Result returned by the [`QueryHandler`].
@@ -17,47 +17,120 @@ pub enum QueryResult<'a> {
     Synapse(Option<&'a Synapse>),
     /// Activation lookup.
     Activation(Option<Activation>),
+    /// Curiosity score lookup.
+    CuriosityScore(Option<f64>),
 }
 
 /// Provides read-only access to the network state.
 pub struct QueryHandler<'a> {
-    projection: &'a NetworkProjection,
+    network: &'a NetworkProjection,
+    curiosity: Option<&'a CuriosityScoreProjection>,
 }
 
 impl<'a> QueryHandler<'a> {
-    /// Creates a new query handler from the given projection reference.
+    /// Creates a new query handler from the given network projection reference.
     pub fn new(projection: &'a NetworkProjection) -> Self {
-        Self { projection }
+        Self {
+            network: projection,
+            curiosity: None,
+        }
+    }
+
+    /// Attaches a curiosity score projection for score lookups.
+    ///
+    /// # Arguments
+    ///
+    /// * `projection` - Projection containing curiosity scores.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aei_framework::application::{Query, QueryHandler, QueryResult};
+    /// use aei_framework::domain::{Activation, CuriosityScoreUpdated, Event, RandomNeuronAdded};
+    /// use aei_framework::infrastructure::projection::{CuriosityScoreProjection, NetworkProjection};
+    /// use uuid::Uuid;
+    ///
+    /// let id = Uuid::new_v4();
+    /// let events = vec![
+    ///     Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation: Activation::ReLU }),
+    ///     Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id: id, old_score: 0.0, new_score: 0.42 }),
+    /// ];
+    /// let network = NetworkProjection::from_events(&events);
+    /// let curiosity = CuriosityScoreProjection::from_events(&events);
+    /// let handler = QueryHandler::new(&network).with_curiosity_projection(&curiosity);
+    /// if let QueryResult::CuriosityScore(Some(score)) = handler.handle(Query::GetCuriosityScore { id }) {
+    ///     assert_eq!(score, 0.42);
+    /// }
+    /// ```
+    pub fn with_curiosity_projection(mut self, projection: &'a CuriosityScoreProjection) -> Self {
+        self.curiosity = Some(projection);
+        self
     }
 
     /// Executes a query and returns a projection of the state.
     pub fn handle(&self, query: Query) -> QueryResult<'a> {
         match query {
-            Query::GetNeuron { id } => QueryResult::Neuron(self.projection.neuron(id)),
-            Query::ListNeurons => QueryResult::Neurons(self.projection.neurons()),
-            Query::ListSynapses => QueryResult::Synapses(self.projection.synapses()),
-            Query::GetSynapse { id } => QueryResult::Synapse(self.projection.synapse(id)),
+            Query::GetNeuron { id } => QueryResult::Neuron(self.network.neuron(id)),
+            Query::ListNeurons => QueryResult::Neurons(self.network.neurons()),
+            Query::ListSynapses => QueryResult::Synapses(self.network.synapses()),
+            Query::GetSynapse { id } => QueryResult::Synapse(self.network.synapse(id)),
             Query::GetNeuronActivation { id } => {
-                QueryResult::Activation(self.projection.activation(id))
+                QueryResult::Activation(self.network.activation(id))
             }
+            Query::GetCuriosityScore { id } => QueryResult::CuriosityScore(
+                self.curiosity.and_then(|c| c.get(id)),
+            ),
         }
     }
 
     /// Convenience method to fetch a neuron directly.
     #[must_use]
     pub fn neuron(&self, id: Uuid) -> Option<&'a Neuron> {
-        self.projection.neuron(id)
+        self.network.neuron(id)
     }
 
     /// Convenience method to fetch a synapse directly.
     #[must_use]
     pub fn synapse(&self, id: Uuid) -> Option<&'a Synapse> {
-        self.projection.synapse(id)
+        self.network.synapse(id)
     }
 
     /// Convenience method to fetch a neuron's activation directly.
     #[must_use]
     pub fn activation(&self, id: Uuid) -> Option<Activation> {
-        self.projection.activation(id)
+        self.network.activation(id)
+    }
+
+    /// Convenience method to fetch a curiosity score directly.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Identifier of the target neuron or synapse.
+    ///
+    /// # Returns
+    ///
+    /// * `Option<f64>` - The curiosity score if present.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aei_framework::application::QueryHandler;
+    /// use aei_framework::domain::{Activation, CuriosityScoreUpdated, Event, RandomNeuronAdded};
+    /// use aei_framework::infrastructure::projection::{CuriosityScoreProjection, NetworkProjection};
+    /// use uuid::Uuid;
+    ///
+    /// let id = Uuid::new_v4();
+    /// let events = vec![
+    ///     Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation: Activation::ReLU }),
+    ///     Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id: id, old_score: 0.0, new_score: 0.5 }),
+    /// ];
+    /// let network = NetworkProjection::from_events(&events);
+    /// let curiosity = CuriosityScoreProjection::from_events(&events);
+    /// let handler = QueryHandler::new(&network).with_curiosity_projection(&curiosity);
+    /// assert_eq!(handler.curiosity_score(id), Some(0.5));
+    /// ```
+    #[must_use]
+    pub fn curiosity_score(&self, id: Uuid) -> Option<f64> {
+        self.curiosity.and_then(|c| c.get(id))
     }
 }

--- a/tests/get_curiosity_score.rs
+++ b/tests/get_curiosity_score.rs
@@ -1,0 +1,25 @@
+use aei_framework::{
+    application::{Query, QueryHandler, QueryResult},
+    domain::{Activation, CuriosityScoreUpdated, Event, RandomNeuronAdded},
+    infrastructure::projection::{CuriosityScoreProjection, NetworkProjection},
+};
+use uuid::Uuid;
+
+#[test]
+fn query_handler_returns_curiosity_score() {
+    let id = Uuid::new_v4();
+    let events = vec![
+        Event::RandomNeuronAdded(RandomNeuronAdded { neuron_id: id, activation: Activation::ReLU }),
+        Event::CuriosityScoreUpdated(CuriosityScoreUpdated { target_id: id, old_score: 0.0, new_score: 0.7 }),
+    ];
+    let network = NetworkProjection::from_events(&events);
+    let curiosity = CuriosityScoreProjection::from_events(&events);
+    let handler = QueryHandler::new(&network).with_curiosity_projection(&curiosity);
+
+    match handler.handle(Query::GetCuriosityScore { id }) {
+        QueryResult::CuriosityScore(Some(score)) => assert!((score - 0.7).abs() < f64::EPSILON),
+        _ => panic!("score missing"),
+    }
+
+    assert_eq!(handler.curiosity_score(id), Some(0.7));
+}


### PR DESCRIPTION
## Summary
- add `GetCuriosityScore` query and support in `QueryHandler`
- expose curiosity scores via `CuriosityScoreProjection`
- document curiosity score retrieval and update glossaries

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b2a1c6f748321ba1c405cc0f71157