### PR TITLE
feat(memory): filter entries by event type

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -17,6 +17,9 @@ A read-only request for information handled separately from commands. See [src/a
 ### Event
 An immutable record describing a state change that occurred as a result of handling a command. Events are persisted to the event store and can be replayed to reconstruct state. See [src/domain/events.rs](src/domain/events.rs).
 
+### Event Type
+Label categorizing a memory entry, enabling queries for specific kinds of experiences.
+
 ### Event Store
 Persistent storage responsible for appending and loading domain events. Implementations live under [src/infrastructure/event_store.rs](src/infrastructure/event_store.rs).
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,10 @@ let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);
-let _entries = qh.handle(MemoryQuery::GetMemoryState);
+let _entries = qh.handle(MemoryQuery::GetByEventType {
+    event_type: "interaction".into(),
+    limit: 10,
+});
 ```
 
 ## Logging

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -170,7 +170,10 @@ let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);
-let _entries = qh.handle(MemoryQuery::GetMemoryState);
+let _entries = qh.handle(MemoryQuery::GetByEventType {
+    event_type: "interaction".into(),
+    limit: 10,
+});
 ```
 
 ## Curiosity Score

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -17,6 +17,9 @@ Demande en lecture seule traitée séparément des commandes. Voir [src/applicat
 ### Événement
 Enregistrement immuable décrivant un changement d'état survenu suite au traitement d'une commande. Les événements sont persistés dans le magasin d'événements et peuvent être rejoués pour reconstruire l'état. Voir [src/domain/events.rs](../../src/domain/events.rs).
 
+### Type d'événement
+Étiquette catégorisant une entrée de mémoire, utilisée pour interroger des types d'expériences spécifiques.
+
 ### Magasin d'événements
 Stockage persistant chargé d'ajouter et de charger les événements de domaine. Les implémentations se trouvent dans [src/infrastructure/event_store.rs](../../src/infrastructure/event_store.rs).
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -168,7 +168,10 @@ let mut store = handler.base.store;
 let events = store.load().unwrap();
 let projection = MemoryProjection::from_events(50, &events);
 let qh = MemoryQueryHandler::new(&projection);
-let _entries = qh.handle(MemoryQuery::GetMemoryState);
+let _entries = qh.handle(MemoryQuery::GetByEventType {
+    event_type: "interaction".into(),
+    limit: 10,
+});
 ```
 
 ## Score de curiosité

--- a/src/application/memory/queries.rs
+++ b/src/application/memory/queries.rs
@@ -9,6 +9,8 @@ pub enum MemoryQuery {
     GetMemoryState,
     /// Retrieve the top `limit` entries by score.
     GetTopEntries { limit: usize },
+    /// Retrieve up to `limit` entries matching `event_type`.
+    GetByEventType { event_type: String, limit: usize },
     /// Retrieve a single entry by identifier.
     GetEntryById { id: Uuid },
 }

--- a/src/application/memory/query_handler.rs
+++ b/src/application/memory/query_handler.rs
@@ -13,6 +13,8 @@ pub enum MemoryQueryResult<'a> {
     Entries(Vec<&'a MemoryEntry>),
     /// Subset of entries.
     TopEntries(Vec<&'a MemoryEntry>),
+    /// Entries filtered by event type.
+    EntriesByEventType(Vec<&'a MemoryEntry>),
     /// Single entry lookup.
     Entry(Option<&'a MemoryEntry>),
 }
@@ -34,6 +36,11 @@ impl<'a> MemoryQueryHandler<'a> {
             MemoryQuery::GetMemoryState => MemoryQueryResult::Entries(self.projection.entries()),
             MemoryQuery::GetTopEntries { limit } => {
                 MemoryQueryResult::TopEntries(self.projection.top_entries(limit))
+            }
+            MemoryQuery::GetByEventType { event_type, limit } => {
+                MemoryQueryResult::EntriesByEventType(
+                    self.projection.entries_by_event_type(&event_type, limit),
+                )
             }
             MemoryQuery::GetEntryById { id } => MemoryQueryResult::Entry(self.projection.entry(id)),
         }

--- a/src/infrastructure/projection/memory_projection.rs
+++ b/src/infrastructure/projection/memory_projection.rs
@@ -43,4 +43,48 @@ impl MemoryProjection {
         entries.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
         entries.into_iter().take(limit).collect()
     }
+
+    /// Returns up to `limit` entries matching `event_type`, ordered by descending score.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - Type tag to filter entries by.
+    /// * `limit` - Maximum number of entries to return.
+    ///
+    /// # Returns
+    ///
+    /// A vector of references to memory entries sorted from highest to lowest score.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aei_framework::domain::{MemoryEntry, MemoryEntryAdded, MemoryEvent};
+    /// use aei_framework::infrastructure::projection::MemoryProjection;
+    /// use chrono::Utc;
+    /// use uuid::Uuid;
+    ///
+    /// let events = vec![MemoryEvent::MemoryEntryAdded(MemoryEntryAdded {
+    ///     entry: MemoryEntry {
+    ///         id: Uuid::new_v4(),
+    ///         timestamp: Utc::now(),
+    ///         event_type: "demo".into(),
+    ///         payload: serde_json::json!({}),
+    ///         score: 0.4,
+    ///     },
+    /// })];
+    /// let projection = MemoryProjection::from_events(10, &events);
+    /// let entries = projection.entries_by_event_type("demo", 5);
+    /// assert_eq!(entries.len(), 1);
+    /// ```
+    #[must_use]
+    pub fn entries_by_event_type(&self, event_type: &str, limit: usize) -> Vec<&MemoryEntry> {
+        let mut entries: Vec<&MemoryEntry> = self
+            .memory
+            .entries
+            .iter()
+            .filter(|e| e.event_type == event_type)
+            .collect();
+        entries.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        entries.into_iter().take(limit).collect()
+    }
 }


### PR DESCRIPTION
## Summary
- add `GetByEventType` memory query
- support event-type filtering and ordering in query handler and projection
- document event-type queries and glossary term

## Testing
- `cargo test`
- `cargo test --test memory_adaptive`

------
https://chatgpt.com/codex/tasks/task_e_689b2f4551848321bad83f332ac85545