### PR TITLE
feat(core): generic memory, scheduler, and event bus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,6 @@ description = "Core of the AEI Framework for dynamic neural networks."
 license = "MPL-2.0"
 publish = false
 
-[workspace]
-members = [
-    "crates/core",
-    "crates/memory",
-    "crates/runtime",
-    "crates/utils",
-]
-resolver = "2"
-
 [dependencies]
 uuid = { version = "1.8", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -23,6 +14,8 @@ log = "0.4"
 rand = "0.8"
 rand_distr = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1.0"
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -8,6 +8,24 @@ The Autonomous & Evolutive Intelligence Framework, a Rust library for building d
 ### Domain-Driven Design (DDD)
 An approach to software development that models complex domains in terms of bounded contexts and ubiquitous language.
 
+### MemoryStore
+Abstraction for CRUD operations on memory items.
+
+### MemoryIndex
+Component providing vector-based search over memory items.
+
+### RetentionPolicy
+Strategy determining whether memory items are kept, archived, or deleted.
+
+### Compactor
+Reduces storage usage by merging or removing memory items.
+
+### Scheduler
+Plans recurring tasks executed on manual ticks.
+
+### EventBus
+In-process publish/subscribe mechanism for events.
+
 ### Command
 An intent to change state in the system. Commands are handled by dedicated command handlers and produce events when successful. See [src/application/commands.rs](src/application/commands.rs).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ _Autonomous & Evolutive Intelligence Framework (AEIF)_
 
 ## Phase 3 — Persistence & Memory Abstraction
 
-- [ ] **`crates/memory`:**
+- [ ] **memory module:**
   - `MemoryStore` trait: put/get/save/load pattern
   - In-memory backend (HashMap)
   - File-based backend (JSON/YAML/TOML)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "aei-core"
-version = "0.1.0"
-edition = "2021"
-description = "Core of the Autonomous & Evolutive Intelligence Framework."
-license = "MPL-2.0"
-
-[dependencies]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,0 @@
-//! Core of the Autonomous & Evolutive Intelligence Framework (AEIF).
-//!
-//! This crate defines foundational traits, types, and behaviors
-//! for building Autonomous Conscious Units (ACUs).

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "aei-memory"
-version = "0.1.0"
-edition = "2021"
-description = "Memory abstractions and persistence mechanisms for ACUs."
-license = "MPL-2.0"
-
-[dependencies]

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,2 +1,0 @@
-//! Memory and persistence abstractions used to store and retrieve
-//! the experience of Autonomous Conscious Units (ACUs).

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "aei-runtime"
-version = "0.1.0"
-edition = "2021"
-description = "Agent runtime responsible for scheduling and orchestration."
-license = "MPL-2.0"
-
-[dependencies]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,2 +1,0 @@
-//! Agent runtime responsible for orchestrating and scheduling
-//! Autonomous Conscious Units (ACUs) within the framework.

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "aei-utils"
-version = "0.1.0"
-edition = "2021"
-description = "Shared utilities for the AEIF workspace."
-license = "MPL-2.0"
-
-[dependencies]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,2 +1,0 @@
-//! Shared utility functions and types used across the
-//! Autonomous & Evolutive Intelligence Framework (AEIF).

--- a/docs/en/memory-interfaces.md
+++ b/docs/en/memory-interfaces.md
@@ -1,0 +1,18 @@
+# Memory Interfaces
+
+The `core::memory` module defines several abstractions for generic memory management:
+
+- `MemoryStore` for CRUD persistence of `MemoryItem` objects.
+- `MemoryIndex` for vector-based search.
+- `RetentionPolicy` for deciding whether items are kept, archived, or deleted.
+- `Compactor` for reducing storage footprint.
+
+## Example
+
+```rust
+use aei_framework::core::memory::{InMemoryStore, MemoryItem, MemoryStore};
+
+let mut store = InMemoryStore::new();
+let id = store.append(MemoryItem::new("Hello"))?;
+let item = store.get(&id)?.unwrap();
+```

--- a/docs/en/scheduler.md
+++ b/docs/en/scheduler.md
@@ -1,0 +1,12 @@
+# Scheduler
+
+The scheduler module registers tasks that run at fixed intervals. Tasks execute when `tick()` is called.
+
+```rust
+use aei_framework::core::scheduler::{InMemoryScheduler, Scheduler};
+use std::time::Duration;
+
+let mut sched = InMemoryScheduler::new();
+sched.schedule(Duration::from_secs(1), Box::new(|| println!("tick")));
+sched.tick();
+```

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -106,3 +106,21 @@ Modèle de lecture associant des identifiants aux scores de curiosité. Voir [sr
 
 ### Requête GetCuriosityScore
 Requête récupérant le score de curiosité d'un neurone ou d'une synapse via [`QueryHandler`](../../src/application/query_handler.rs).
+
+### MemoryStore
+Abstraction de stockage CRUD pour les éléments de mémoire.
+
+### MemoryIndex
+Fournit une recherche vectorielle sur les éléments de mémoire.
+
+### RetentionPolicy
+Stratégie déterminant si les éléments de mémoire doivent être conservés, archivés ou supprimés.
+
+### Compactor
+Composant réduisant l'espace de stockage en fusionnant ou supprimant des éléments.
+
+### Scheduler
+Planificateur de tâches récurrentes exécutées lors des ticks.
+
+### EventBus
+Mécanisme interne de publication/abonnement pour les événements.

--- a/docs/fr/ROADMAP.md
+++ b/docs/fr/ROADMAP.md
@@ -43,7 +43,7 @@ _Framework d'Intelligence Autonome & Évolutive (AEIF)_
 
 ## Phase 3 — Persistance & abstraction de mémoire
 
-- [ ] **`crates/memory` :**
+- [ ] **module memory :**
   - Trait `MemoryStore` : modèle put/get/save/load
   - Backend en mémoire (HashMap)
   - Backend fichier (JSON/YAML/TOML)

--- a/docs/fr/interfaces-memoire.md
+++ b/docs/fr/interfaces-memoire.md
@@ -1,0 +1,18 @@
+# Interfaces mémoire
+
+Le module `core::memory` fournit plusieurs abstractions génériques pour la gestion de mémoire :
+
+- `MemoryStore` pour la persistance CRUD des `MemoryItem`.
+- `MemoryIndex` pour la recherche vectorielle.
+- `RetentionPolicy` pour décider si les éléments sont conservés, archivés ou supprimés.
+- `Compactor` pour réduire l'espace de stockage.
+
+## Exemple
+
+```rust
+use aei_framework::core::memory::{InMemoryStore, MemoryItem, MemoryStore};
+
+let mut store = InMemoryStore::new();
+let id = store.append(MemoryItem::new("Bonjour"))?;
+let item = store.get(&id)?.unwrap();
+```

--- a/docs/fr/scheduler.md
+++ b/docs/fr/scheduler.md
@@ -1,0 +1,12 @@
+# Scheduler
+
+Le module Scheduler enregistre des tâches exécutées à intervalles fixes. Les tâches sont lancées lorsque `tick()` est appelé.
+
+```rust
+use aei_framework::core::scheduler::{InMemoryScheduler, Scheduler};
+use std::time::Duration;
+
+let mut sched = InMemoryScheduler::new();
+sched.schedule(Duration::from_secs(1), Box::new(|| println!("tick")));
+sched.tick();
+```

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 /// Runs the memory example.
 fn main() {
     env_logger::init();
-    let path = std::env::temp_dir().join(format!("aei_memory_{}.log", Uuid::new_v4()));
+    let path = std::env::temp_dir().join(format!("aei_framework_memory_{}.log", Uuid::new_v4()));
     let store = FileMemoryEventStore::new(path.clone());
 
     // Insert a new memory entry.

--- a/src/core/event_bus/mod.rs
+++ b/src/core/event_bus/mod.rs
@@ -1,0 +1,5 @@
+//! Internal publish/subscribe bus.
+
+pub mod traits;
+
+pub use traits::{EventBus, InMemoryEventBus};

--- a/src/core/event_bus/traits.rs
+++ b/src/core/event_bus/traits.rs
@@ -1,0 +1,52 @@
+use crossbeam_channel::{unbounded, Receiver, Sender};
+
+/// Publish/subscribe event bus.
+///
+/// # Examples
+/// ```
+/// use aei_framework::core::event_bus::{EventBus, InMemoryEventBus};
+/// let mut bus: InMemoryEventBus<u32> = InMemoryEventBus::new();
+/// let rx = bus.subscribe();
+/// bus.publish(1);
+/// assert_eq!(rx.recv().unwrap(), 1);
+/// ```
+pub trait EventBus<T: Clone + Send + 'static> {
+    /// Publishes an event to all subscribers.
+    fn publish(&self, event: T);
+    /// Subscribes to events, returning a receiver channel.
+    fn subscribe(&mut self) -> Receiver<T>;
+}
+
+/// In-memory implementation of [`EventBus`].
+pub struct InMemoryEventBus<T: Clone + Send + 'static> {
+    subscribers: Vec<Sender<T>>,
+}
+
+impl<T: Clone + Send + 'static> Default for InMemoryEventBus<T> {
+    fn default() -> Self {
+        Self {
+            subscribers: Vec::new(),
+        }
+    }
+}
+
+impl<T: Clone + Send + 'static> InMemoryEventBus<T> {
+    /// Creates a new empty bus.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<T: Clone + Send + 'static> EventBus<T> for InMemoryEventBus<T> {
+    fn publish(&self, event: T) {
+        for sub in &self.subscribers {
+            let _ = sub.send(event.clone());
+        }
+    }
+
+    fn subscribe(&mut self) -> Receiver<T> {
+        let (tx, rx) = unbounded();
+        self.subscribers.push(tx);
+        rx
+    }
+}

--- a/src/core/memory/compactor.rs
+++ b/src/core/memory/compactor.rs
@@ -1,0 +1,17 @@
+use super::store::{MemoryStore, Result};
+
+/// Reduces memory storage by merging or removing items.
+pub trait Compactor {
+    /// Compacts the given store.
+    fn compact(&mut self, store: &mut dyn MemoryStore) -> Result<()>;
+}
+
+/// No-op compactor used for tests.
+#[derive(Default)]
+pub struct NoopCompactor;
+
+impl Compactor for NoopCompactor {
+    fn compact(&mut self, _store: &mut dyn MemoryStore) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/core/memory/events.rs
+++ b/src/core/memory/events.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+use super::store::MemoryId;
+
+/// Emitted when a new memory item is appended.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryItemAppended {
+    /// Identifier of the appended item.
+    pub id: MemoryId,
+}
+
+/// Emitted when an existing memory item is updated.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryItemUpdated {
+    /// Identifier of the updated item.
+    pub id: MemoryId,
+}
+
+/// Emitted when a memory item is deleted.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryItemDeleted {
+    /// Identifier of the removed item.
+    pub id: MemoryId,
+}
+
+/// Emitted when a memory item is archived.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryItemArchived {
+    /// Identifier of the archived item.
+    pub id: MemoryId,
+}
+
+/// Emitted when memory compaction has occurred.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryCompacted;
+
+/// Emitted when the retention policy changes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryRetentionPolicyChanged;
+
+/// Emitted when an index has been rebuilt.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IndexRebuilt;

--- a/src/core/memory/index.rs
+++ b/src/core/memory/index.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::store::{MemoryId, Result};
+
+/// Result of a search in a [`MemoryIndex`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SearchResult {
+    /// Identifier of the found item.
+    pub id: MemoryId,
+    /// Similarity score.
+    pub score: f32,
+}
+
+/// Interface for vector or full text indices.
+pub trait MemoryIndex {
+    /// Adds an embedding vector associated with an item identifier.
+    fn add_embedding(&mut self, id: &MemoryId, vector: Vec<f32>) -> Result<()>;
+    /// Searches the index returning the top `k` most similar vectors.
+    fn search(&self, query: Vec<f32>, k: usize) -> Result<Vec<SearchResult>>;
+}
+
+/// Naive in-memory implementation of [`MemoryIndex`].
+#[derive(Default)]
+pub struct InMemoryIndex {
+    vectors: HashMap<MemoryId, Vec<f32>>,
+}
+
+impl InMemoryIndex {
+    /// Creates a new empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MemoryIndex for InMemoryIndex {
+    fn add_embedding(&mut self, id: &MemoryId, vector: Vec<f32>) -> Result<()> {
+        self.vectors.insert(*id, vector);
+        Ok(())
+    }
+
+    fn search(&self, query: Vec<f32>, k: usize) -> Result<Vec<SearchResult>> {
+        let mut results: Vec<SearchResult> = self
+            .vectors
+            .iter()
+            .map(|(id, v)| {
+                let score = cosine_similarity(&query, v);
+                SearchResult { id: *id, score }
+            })
+            .collect();
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.truncate(k);
+        Ok(results)
+    }
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot / (norm_a * norm_b)
+    }
+}

--- a/src/core/memory/mod.rs
+++ b/src/core/memory/mod.rs
@@ -1,0 +1,13 @@
+//! Memory abstractions and utilities.
+
+pub mod compactor;
+pub mod events;
+pub mod index;
+pub mod retention;
+pub mod store;
+
+pub use compactor::{Compactor, NoopCompactor};
+pub use events::*;
+pub use index::{InMemoryIndex, MemoryIndex, SearchResult};
+pub use retention::{RetentionAction, RetentionPolicy, TtlRetentionPolicy};
+pub use store::{InMemoryStore, MemoryError, MemoryId, MemoryItem, MemoryStore, Result};

--- a/src/core/memory/retention.rs
+++ b/src/core/memory/retention.rs
@@ -1,0 +1,42 @@
+use chrono::{Duration, Utc};
+
+use super::store::MemoryItem;
+
+/// Action decided by a [`RetentionPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetentionAction {
+    /// Keep the item as-is.
+    Keep,
+    /// Archive the item to long-term storage.
+    Archive,
+    /// Permanently remove the item.
+    Delete,
+}
+
+/// Evaluates whether memory items should be kept, archived, or deleted.
+pub trait RetentionPolicy {
+    /// Evaluates the given item and returns the action to apply.
+    fn evaluate(&self, item: &MemoryItem) -> RetentionAction;
+}
+
+/// Simple time-to-live retention policy.
+pub struct TtlRetentionPolicy {
+    ttl: Duration,
+}
+
+impl TtlRetentionPolicy {
+    /// Creates a policy that deletes items older than the given TTL.
+    pub fn new(ttl: Duration) -> Self {
+        Self { ttl }
+    }
+}
+
+impl RetentionPolicy for TtlRetentionPolicy {
+    fn evaluate(&self, item: &MemoryItem) -> RetentionAction {
+        if Utc::now() - item.timestamp > self.ttl {
+            RetentionAction::Delete
+        } else {
+            RetentionAction::Keep
+        }
+    }
+}

--- a/src/core/memory/store.rs
+++ b/src/core/memory/store.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Identifier used for memory items.
+pub type MemoryId = Uuid;
+
+/// Item persisted by a [`MemoryStore`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryItem {
+    /// Unique identifier for the item.
+    pub id: MemoryId,
+    /// Textual content associated with the item.
+    pub content: String,
+    /// Timestamp when the item was created.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl MemoryItem {
+    /// Creates a new memory item.
+    ///
+    /// # Examples
+    /// ```
+    /// use aei_framework::core::memory::MemoryItem;
+    /// let item = MemoryItem::new("Hello");
+    /// assert_eq!(item.content, "Hello");
+    /// ```
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            content: content.into(),
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+/// Errors returned by memory operations.
+#[derive(Debug, Error)]
+pub enum MemoryError {
+    /// The requested item does not exist.
+    #[error("memory item not found")]
+    NotFound,
+    /// Generic storage error.
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+/// Result type used by memory APIs.
+pub type Result<T> = std::result::Result<T, MemoryError>;
+
+/// Generic CRUD operations for memory items.
+pub trait MemoryStore {
+    /// Appends a new item and returns its identifier.
+    fn append(&mut self, item: MemoryItem) -> Result<MemoryId>;
+    /// Retrieves an item by identifier.
+    fn get(&self, id: &MemoryId) -> Result<Option<MemoryItem>>;
+    /// Deletes an item by identifier.
+    fn delete(&mut self, id: &MemoryId) -> Result<()>;
+}
+
+/// In-memory [`MemoryStore`] implementation backed by a `HashMap`.
+#[derive(Default)]
+pub struct InMemoryStore {
+    items: HashMap<MemoryId, MemoryItem>,
+}
+
+impl InMemoryStore {
+    /// Creates a new empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MemoryStore for InMemoryStore {
+    fn append(&mut self, item: MemoryItem) -> Result<MemoryId> {
+        let id = item.id;
+        self.items.insert(id, item);
+        Ok(id)
+    }
+
+    fn get(&self, id: &MemoryId) -> Result<Option<MemoryItem>> {
+        Ok(self.items.get(id).cloned())
+    }
+
+    fn delete(&mut self, id: &MemoryId) -> Result<()> {
+        self.items
+            .remove(id)
+            .map(|_| ())
+            .ok_or(MemoryError::NotFound)
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,5 @@
+//! Core modules with generic utilities.
+
+pub mod event_bus;
+pub mod memory;
+pub mod scheduler;

--- a/src/core/scheduler/mod.rs
+++ b/src/core/scheduler/mod.rs
@@ -1,0 +1,59 @@
+//! Task scheduling utilities.
+
+use std::time::{Duration, Instant};
+
+/// Schedules recurring tasks.
+///
+/// # Examples
+/// ```
+/// use aei_framework::core::scheduler::{InMemoryScheduler, Scheduler};
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+/// use std::sync::Arc;
+/// use std::time::Duration;
+/// let mut sched = InMemoryScheduler::new();
+/// let counter = Arc::new(AtomicUsize::new(0));
+/// let c = Arc::clone(&counter);
+/// sched.schedule(Duration::from_millis(0), Box::new(move || {
+///     c.fetch_add(1, Ordering::SeqCst);
+/// }));
+/// sched.tick();
+/// assert_eq!(counter.load(Ordering::SeqCst), 1);
+/// ```
+pub trait Scheduler {
+    /// Schedules a task to run every `interval`.
+    fn schedule(&mut self, interval: Duration, task: Box<dyn FnMut() + Send>);
+    /// Executes due tasks.
+    fn tick(&mut self);
+}
+
+/// Entry in the scheduler's task list.
+type Task = (Instant, Duration, Box<dyn FnMut() + Send>);
+
+/// In-memory scheduler running tasks on manual ticks.
+#[derive(Default)]
+pub struct InMemoryScheduler {
+    tasks: Vec<Task>,
+}
+
+impl InMemoryScheduler {
+    /// Creates an empty scheduler.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Scheduler for InMemoryScheduler {
+    fn schedule(&mut self, interval: Duration, task: Box<dyn FnMut() + Send>) {
+        self.tasks.push((Instant::now() + interval, interval, task));
+    }
+
+    fn tick(&mut self) {
+        let now = Instant::now();
+        for (next_run, interval, task) in &mut self.tasks {
+            if now >= *next_run {
+                task();
+                *next_run = now + *interval;
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //! modular neural networks.
 
 pub mod application;
+pub mod core;
 pub mod domain;
 pub mod infrastructure;
 

--- a/tests/event_bus_it.rs
+++ b/tests/event_bus_it.rs
@@ -1,0 +1,9 @@
+use aei_framework::core::event_bus::{EventBus, InMemoryEventBus};
+
+#[test]
+fn subscriber_receives_published_event() {
+    let mut bus: InMemoryEventBus<u32> = InMemoryEventBus::new();
+    let rx = bus.subscribe();
+    bus.publish(7);
+    assert_eq!(rx.recv().unwrap(), 7);
+}

--- a/tests/memory_store_it.rs
+++ b/tests/memory_store_it.rs
@@ -1,0 +1,23 @@
+use aei_framework::core::memory::{
+    InMemoryIndex, InMemoryStore, MemoryIndex, MemoryItem, MemoryStore,
+};
+
+#[test]
+fn store_crud_and_search() {
+    let mut store = InMemoryStore::new();
+    let mut index = InMemoryIndex::new();
+
+    let item = MemoryItem::new("Hello World");
+    let id = store.append(item.clone()).unwrap();
+    index.add_embedding(&id, vec![1.0, 0.0, 0.0]).unwrap();
+
+    let fetched = store.get(&id).unwrap().unwrap();
+    assert_eq!(fetched.content, "Hello World");
+
+    let results = index.search(vec![1.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, id);
+
+    store.delete(&id).unwrap();
+    assert!(store.get(&id).unwrap().is_none());
+}

--- a/tests/retention_compactor_it.rs
+++ b/tests/retention_compactor_it.rs
@@ -1,0 +1,20 @@
+use aei_framework::core::memory::{
+    Compactor, InMemoryStore, MemoryItem, NoopCompactor, RetentionAction, RetentionPolicy,
+    TtlRetentionPolicy,
+};
+
+#[test]
+fn ttl_retention_deletes_old_items() {
+    let mut item = MemoryItem::new("temp");
+    // Set timestamp in the past
+    item.timestamp = chrono::Utc::now() - chrono::Duration::seconds(2);
+    let policy = TtlRetentionPolicy::new(chrono::Duration::seconds(1));
+    assert_eq!(policy.evaluate(&item), RetentionAction::Delete);
+}
+
+#[test]
+fn noop_compactor_runs_without_error() {
+    let mut store = InMemoryStore::new();
+    let mut compactor = NoopCompactor::default();
+    compactor.compact(&mut store).unwrap();
+}

--- a/tests/retention_compactor_it.rs
+++ b/tests/retention_compactor_it.rs
@@ -15,6 +15,6 @@ fn ttl_retention_deletes_old_items() {
 #[test]
 fn noop_compactor_runs_without_error() {
     let mut store = InMemoryStore::new();
-    let mut compactor = NoopCompactor::default();
+    let mut compactor = NoopCompactor;
     compactor.compact(&mut store).unwrap();
 }

--- a/tests/scheduler_it.rs
+++ b/tests/scheduler_it.rs
@@ -1,0 +1,20 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aei_framework::core::scheduler::{InMemoryScheduler, Scheduler};
+
+#[test]
+fn scheduled_task_runs_on_tick() {
+    let mut scheduler = InMemoryScheduler::new();
+    let counter = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&counter);
+    scheduler.schedule(
+        Duration::from_millis(0),
+        Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }),
+    );
+    scheduler.tick();
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary
- inline generic memory store, index, retention, and compaction modules under `core::memory`
- provide in-memory scheduler and event bus via `core::scheduler` and `core::event_bus`
- update documentation and tests to use the new core modules

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689ca461ada4832198f4d3957631b749